### PR TITLE
[MAPA-510] feat: creates handle-answer endpoint

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -2,3 +2,4 @@ export { default as sign } from "./src/sign";
 export { default as auth } from "./src/auth";
 export { default as featureFlag } from "./src/featureFlag";
 export { default as createConfirmation } from "./src/createConfirmation";
+export { default as handleAnswer } from "./src/handleAnswer";

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -74,6 +74,14 @@ functions:
           authorizer:
             name: auth
             type: request
+  
+  handleAnswer:
+    handler: handler.handleAnswer
+    timeout: 30
+    events:
+      - httpApi:
+          path: /handle-answer
+          method: POST
 
 plugins:
   - serverless-webpack

--- a/src/__tests__/createConfirmation.spec.ts
+++ b/src/__tests__/createConfirmation.spec.ts
@@ -20,7 +20,7 @@ const defaultBody = {
 
 const confirmMatchMock = jest.spyOn(confirmMatch, "default");
 
-describe("/create-confitmation endpoint", () => {
+describe("/create-confirmation endpoint", () => {
   it("should return an error res when no body is provided to the req", async () => {
     await createConfirmation(
       {

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -1,0 +1,100 @@
+import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import { handleAnswer } from "../../handler";
+import * as sendReply from "../reply/sendReply";
+import { replyMock } from "../reply/__mocks__";
+
+const callback = jest.fn();
+
+const defaultBody =
+  "MessageType=text&Body=Oi&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5511123456789";
+
+const sendReplyMock = jest.spyOn(sendReply, "default");
+
+describe("/handle-answer endpoint", () => {
+  it("should return an error res when no body is provided to the req", async () => {
+    await handleAnswer(
+      {
+        body: null,
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        error: "Validation error: MessageType is a required field",
+      }),
+    });
+  });
+
+  it("should return an error res when req body is invalid", async () => {
+    await handleAnswer(
+      {
+        body: JSON.stringify({
+          MessageSid: "ABC",
+        }),
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        error: `Validation error: MessageType is a required field`,
+      }),
+    });
+  });
+
+  it("should call sendReply with correct params", async () => {
+    await handleAnswer(
+      {
+        body: defaultBody,
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+
+    expect(sendReplyMock).toHaveBeenNthCalledWith(
+      1,
+      "text",
+      "whatsapp%3A%2B5511123456789",
+      undefined
+    );
+  });
+
+  it("should return an error if the reply wasn't correctly sent", async () => {
+    sendReplyMock.mockResolvedValueOnce(null);
+
+    await handleAnswer(
+      {
+        body: defaultBody,
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: `Couldn't send reply to phone number: whatsapp%3A%2B5511123456789`,
+      }),
+    });
+  });
+
+  it("should return the reply", async () => {
+    sendReplyMock.mockResolvedValueOnce(replyMock);
+
+    await handleAnswer(
+      {
+        body: defaultBody,
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 200,
+      body: JSON.stringify({ message: replyMock }),
+    });
+  });
+});

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -22,7 +22,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 400,
       body: JSON.stringify({
-        error: "Validation error: MessageType is a required field",
+        error: "Validation error: From is a required field",
       }),
     });
   });
@@ -40,7 +40,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 400,
       body: JSON.stringify({
-        error: `Validation error: MessageType is a required field`,
+        error: `Validation error: From is a required field`,
       }),
     });
   });
@@ -56,14 +56,15 @@ describe("/handle-answer endpoint", () => {
 
     expect(sendReplyMock).toHaveBeenNthCalledWith(
       1,
-      "text",
       "whatsapp%3A%2B5511123456789",
       undefined
     );
   });
 
   it("should return an error if the reply wasn't correctly sent", async () => {
-    sendReplyMock.mockResolvedValueOnce(null);
+    sendReplyMock.mockRejectedValue(
+      new Error(`Couldn't send whatsapp message to phone: 5511123456789`)
+    );
 
     await handleAnswer(
       {
@@ -76,7 +77,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 500,
       body: JSON.stringify({
-        error: `Couldn't send reply to phone number: whatsapp%3A%2B5511123456789`,
+        error: `Couldn't send whatsapp message to phone: 5511123456789`,
       }),
     });
   });

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
+//ZENDESK
 export const ZENDESK_SUBDOMAIN = process.env["ZENDESK_SUBDOMAIN"];
 export const ZENDESK_API_URL = `${ZENDESK_SUBDOMAIN}/api/v2`;
 export const ZENDESK_API_USER = `${process.env["ZENDESK_API_USER"]}/token`;
@@ -12,11 +13,31 @@ export const ZENDESK_TICKET_WAITING_FOR_CONFIRMATION_STATUS =
 export const ZENDESK_USER_WAITING_FOR_CONFIRMATION_STATUS =
   "indisponivel_aguardando_confirmacao";
 
+// TWILIO
 export const TWILIO_ACCOUNT_SID = process.env["TWILIO_ACCOUNT_SID"];
 export const TWILIO_AUTH_TOKEN = process.env["TWILIO_AUTH_TOKEN"];
 
+// WHATSAPP
 export const WHATSAPP_TEMPLATE_WITH_CITY_ID =
   "HX77fce501ec6df2b537d23eee89f330d7";
 export const WHATSAPP_TEMPLATE_WITHOUT_CITY_ID =
   "HX08285d533e24c762d17ec62b96fdf409";
 export const WHATSAPP_SENDER_ID = "MG079062f161fcf64622214b97dfe44e3c";
+export const WHATSAPP_GENERIC_REPLY = `Você está em um canal de mensagens automáticas. Mas saiba que estamos aqui para ajudar!
+
+Se precisar conversar com alguém da nossa equipe, por favor, sinta-se à vontade para nos contatar pelo e-mail: voluntaria@mapadoacolhimento.org`;
+export const WHATSAPP_POSITIVE_REPLY = `Obrigada por confirmar sua disponibilidade! 💜 Vamos compartilhar seu contato com a acolhida. Agora é só aguardar o contato dela para que vocês iniciem o atendimento!
+
+📩 *Pedimos que fique atenta ao seu e-mail, pois as próximas atualizações serão enviadas por lá!*`;
+// precisamos utilizar um template para a negativa, pois a mensagem possui botões
+export const WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID =
+  "HX0933a196163d79735d6ec3871672ce14";
+export const WHATSAPP_CONTINUE_AVAILABLE_REPLY = `Obrigada pelo seu retorno! Em breve você receberá outras oportunidades de atendimento. 💜`;
+export const WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID =
+  "HX3ccc5212f22ecc0dbb2d27096374fb2c";
+
+// VOLUNTEER ANSWERS
+export const POSITIVE_ANSWER = "Sim";
+export const NEGATIVE_ANSWER = "Não";
+export const CONTINUE_AVAILABLE_ANSWER = "É+um+caso+pontual";
+export const UNREGISTRATION_ANSWER = "Quero+descadastrar";

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -5,10 +5,13 @@ import type {
 } from "aws-lambda";
 import { object, string } from "yup";
 import { getErrorMessage, stringfyBigInt } from "./utils";
-import paramsToJson from "./utils/paramsToJson";
+import { parseParamsToJson } from "./utils";
 
 const bodySchema = object({
-  SmsMessageSid: string(),
+  MessageSid: string().required(),
+  Body: string().required(),
+  MessageType: string(),
+  ButtonText: string(),
 }).required();
 
 export default async function handler(
@@ -19,13 +22,9 @@ export default async function handler(
   try {
     const body = event.body;
 
-    console.log({ body });
-
-    const parsedBody = body
-      ? (paramsToJson(body) as unknown)
-      : (Object.create(null) as Record<string, unknown>);
-
-    console.log({ parsedBody });
+    const parsedBody =
+      (parseParamsToJson(body) as unknown) ||
+      (Object.create(null) as Record<string, unknown>);
 
     const validatedBody = await bodySchema.validate(parsedBody);
 

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -34,20 +34,18 @@ export default async function handler(
 
     const validatedBody = await bodySchema.validate(parsedBody);
 
-    console.log({ validatedBody });
-
     const {
       From: from,
       MessageType: messageType,
       ButtonText: buttonText,
     } = validatedBody;
 
-    const reply = sendReply(messageType, from, buttonText);
+    const reply = await sendReply(messageType, from, buttonText);
 
-    console.log(reply);
+    if (!reply) throw new Error(`Couldn't send reply to phone number: ${from}`);
 
     const bodyRes = JSON.stringify({
-      message: stringfyBigInt(validatedBody),
+      message: stringfyBigInt(reply),
     });
 
     return callback(null, {

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -1,0 +1,63 @@
+import type {
+  APIGatewayEvent,
+  Context,
+  APIGatewayProxyCallback,
+} from "aws-lambda";
+import { object, string } from "yup";
+import { getErrorMessage, stringfyBigInt } from "./utils";
+import paramsToJson from "./utils/paramsToJson";
+
+const bodySchema = object({
+  SmsMessageSid: string(),
+}).required();
+
+export default async function handler(
+  event: APIGatewayEvent,
+  _context: Context,
+  callback: APIGatewayProxyCallback
+) {
+  try {
+    const body = event.body;
+
+    console.log({ body });
+
+    const parsedBody = body
+      ? (paramsToJson(body) as unknown)
+      : (Object.create(null) as Record<string, unknown>);
+
+    console.log({ parsedBody });
+
+    const validatedBody = await bodySchema.validate(parsedBody);
+
+    const bodyRes = JSON.stringify({
+      message: stringfyBigInt(validatedBody),
+    });
+
+    return callback(null, {
+      statusCode: 200,
+      body: bodyRes,
+    });
+  } catch (e) {
+    const error = e as Record<string, unknown>;
+    if (error["name"] === "ValidationError") {
+      const errorMsg = `Validation error: ${getErrorMessage(error)}`;
+
+      console.error(`[handle-answer] - [400]: ${errorMsg}`);
+
+      return callback(null, {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: errorMsg,
+        }),
+      });
+    }
+
+    const errorMsg = getErrorMessage(error);
+    console.error(`[handle-answer] - [500]: ${errorMsg}`);
+
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({ error: errorMsg }),
+    });
+  }
+}

--- a/src/matchConfirmation/__mocks__/utils.ts
+++ b/src/matchConfirmation/__mocks__/utils.ts
@@ -13,7 +13,7 @@ import type { ZendeskTicket, ZendeskUser } from "../../types";
 import type { TwilioMessage } from "../../types/Twilio";
 import * as updateTicket from "../../zendeskClient/updateTicket";
 import * as updateUser from "../../zendeskClient/updateUser";
-import * as createMessage from "../../twilioClient/createMessage";
+import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
 
 export const supportRequestMock = {
   supportRequestId: 1,
@@ -77,8 +77,8 @@ export const updatedUserMock = {
   },
 } as ZendeskUser;
 
-export const createMessageMock = jest
-  .spyOn(createMessage, "default")
+export const sendTemplateMessageMock = jest
+  .spyOn(sendTemplateMessage, "default")
   .mockImplementation(() => Promise.resolve(null));
 
 export const sentMessageMock = {

--- a/src/matchConfirmation/__tests__/confirmMatch.spec.ts
+++ b/src/matchConfirmation/__tests__/confirmMatch.spec.ts
@@ -2,10 +2,10 @@ import * as confirmationLogic from "../matchConfirmationLogic";
 import confirmMatch from "../confirmMatch";
 import { prismaMock } from "../../setupTests";
 import {
-  createMessageMock,
   matchConfirmationMock,
   matchInfoMock,
   msrZendeskTicketMock,
+  sendTemplateMessageMock,
   sentMessageMock,
   supportRequestMock,
   updatedUserMock,
@@ -40,7 +40,7 @@ const sendWhatsAppMessageMock = jest.spyOn(
 
 describe("confirmMatch", () => {
   beforeEach(() => {
-    createMessageMock.mockResolvedValueOnce(sentMessageMock);
+    sendTemplateMessageMock.mockResolvedValueOnce(sentMessageMock);
     updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
     prismaMock.supportRequests.update.mockResolvedValue(supportRequestMock);
     updateUserMock.mockResolvedValueOnce(updatedUserMock);

--- a/src/matchConfirmation/__tests__/matchConfirmationLogic.spec.ts
+++ b/src/matchConfirmation/__tests__/matchConfirmationLogic.spec.ts
@@ -9,10 +9,10 @@ import {
 } from "../matchConfirmationLogic";
 import {
   cityMock,
-  createMessageMock,
   matchConfirmationMock,
   matchInfoMock,
   msrZendeskTicketMock,
+  sendTemplateMessageMock,
   sentMessageMock,
   supportRequestMock,
   updatedUserMock,
@@ -120,7 +120,7 @@ describe("makeVolunteerUnavailable", () => {
 
 describe("sendWhatsAppMessage", () => {
   it("should call createMessage with WHATSAPP_TEMPLATE_WITHOUT_CITY_ID if msr doesn't have city information", async () => {
-    createMessageMock.mockResolvedValueOnce(sentMessageMock);
+    sendTemplateMessageMock.mockResolvedValueOnce(sentMessageMock);
 
     await sendWhatsAppMessage(volunteerMock, {
       ...supportRequestMock,
@@ -128,7 +128,7 @@ describe("sendWhatsAppMessage", () => {
       state: "not_found",
     });
 
-    expect(createMessageMock).toHaveBeenNthCalledWith(
+    expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
       1,
       WHATSAPP_TEMPLATE_WITHOUT_CITY_ID,
       volunteerMock.phone,
@@ -139,7 +139,7 @@ describe("sendWhatsAppMessage", () => {
   });
 
   it("should call createMessage with WHATSAPP_TEMPLATE_WITH_CITY_ID if msr has city information", async () => {
-    createMessageMock.mockResolvedValueOnce(sentMessageMock);
+    sendTemplateMessageMock.mockResolvedValueOnce(sentMessageMock);
     prismaMock.cities.findFirst.mockResolvedValue(cityMock);
 
     await sendWhatsAppMessage(volunteerMock, {
@@ -148,7 +148,7 @@ describe("sendWhatsAppMessage", () => {
       state: "SP",
     });
 
-    expect(createMessageMock).toHaveBeenNthCalledWith(
+    expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
       1,
       WHATSAPP_TEMPLATE_WITH_CITY_ID,
       volunteerMock.phone,
@@ -160,7 +160,7 @@ describe("sendWhatsAppMessage", () => {
   });
 
   it("should throw an error if message wasn't sent", async () => {
-    createMessageMock.mockResolvedValueOnce(null);
+    sendTemplateMessageMock.mockResolvedValueOnce(null);
 
     await expect(
       sendWhatsAppMessage(volunteerMock, supportRequestMock)
@@ -170,7 +170,7 @@ describe("sendWhatsAppMessage", () => {
   });
 
   it("should return the message sent to volunteer", async () => {
-    createMessageMock.mockResolvedValueOnce(sentMessageMock);
+    sendTemplateMessageMock.mockResolvedValueOnce(sentMessageMock);
 
     const res = await sendWhatsAppMessage(volunteerMock, supportRequestMock);
 

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -10,7 +10,7 @@ import client from "../prismaClient";
 import updateTicket from "../zendeskClient/updateTicket";
 import type { ZendeskUser } from "../types";
 import updateUser from "../zendeskClient/updateUser";
-import createMessage from "../twilioClient/createMessage";
+import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
 
 export async function createMatchConfirmation(
   supportRequest: Pick<SupportRequests, "supportRequestId" | "msrId">,
@@ -142,7 +142,7 @@ export async function sendWhatsAppMessage(
       1: volunteer.firstName,
     };
 
-    const message = await createMessage(
+    const message = await sendTemplateMessage(
       WHATSAPP_TEMPLATE_WITHOUT_CITY_ID,
       volunteer.phone,
       contentVariables
@@ -177,7 +177,7 @@ export async function sendWhatsAppMessage(
     2: cityPrettyName,
   };
 
-  const message = await createMessage(
+  const message = await sendTemplateMessage(
     WHATSAPP_TEMPLATE_WITH_CITY_ID,
     volunteer.phone,
     contentVariables

--- a/src/reply/__mocks__/index.ts
+++ b/src/reply/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/src/reply/__mocks__/utils.ts
+++ b/src/reply/__mocks__/utils.ts
@@ -1,0 +1,17 @@
+import * as sendOpenReply from "../../twilioClient/sendOpenReply";
+import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
+import type { TwilioMessage } from "../../types";
+
+export const sendOpenReplyMock = jest
+  .spyOn(sendOpenReply, "default")
+  .mockImplementation(() => Promise.resolve(null));
+
+export const sendTemplateMessageMock = jest
+  .spyOn(sendTemplateMessage, "default")
+  .mockImplementation(() => Promise.resolve(null));
+
+export const replyMock = {
+  status: "accepted",
+} as TwilioMessage;
+
+export const volunteerPhoneMock = "5511123456789";

--- a/src/reply/__tests__/replyLogic.spec.ts
+++ b/src/reply/__tests__/replyLogic.spec.ts
@@ -36,6 +36,14 @@ describe("replyLogic", () => {
       );
     });
 
+    it("should throw an error if message wasn't sent", async () => {
+      sendOpenReplyMock.mockResolvedValueOnce(null);
+
+      await expect(sendGenericReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
+      );
+    });
+
     it("should return the reply that was sent", async () => {
       const res = await sendGenericReply(volunteerPhoneMock);
 
@@ -51,6 +59,14 @@ describe("replyLogic", () => {
         1,
         WHATSAPP_POSITIVE_REPLY,
         volunteerPhoneMock
+      );
+    });
+
+    it("should throw an error if message wasn't sent", async () => {
+      sendOpenReplyMock.mockResolvedValueOnce(null);
+
+      await expect(sendPositiveReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
       );
     });
 
@@ -73,6 +89,14 @@ describe("replyLogic", () => {
       );
     });
 
+    it("should throw an error if message wasn't sent", async () => {
+      sendTemplateMessageMock.mockResolvedValueOnce(null);
+
+      await expect(sendNegativeReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
+      );
+    });
+
     it("should return the reply that was sent", async () => {
       const res = await sendNegativeReply(volunteerPhoneMock);
 
@@ -88,6 +112,16 @@ describe("replyLogic", () => {
         1,
         WHATSAPP_CONTINUE_AVAILABLE_REPLY,
         volunteerPhoneMock
+      );
+    });
+
+    it("should throw an error if message wasn't sent", async () => {
+      sendOpenReplyMock.mockResolvedValueOnce(null);
+
+      await expect(
+        sendContinueAvailableReply(volunteerPhoneMock)
+      ).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
       );
     });
 
@@ -107,6 +141,14 @@ describe("replyLogic", () => {
         WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
         volunteerPhoneMock,
         {}
+      );
+    });
+
+    it("should throw an error if message wasn't sent", async () => {
+      sendTemplateMessageMock.mockResolvedValueOnce(null);
+
+      await expect(sendUnregistrationReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
       );
     });
 

--- a/src/reply/__tests__/replyLogic.spec.ts
+++ b/src/reply/__tests__/replyLogic.spec.ts
@@ -1,0 +1,119 @@
+import {
+  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_GENERIC_REPLY,
+  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+  WHATSAPP_POSITIVE_REPLY,
+  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+} from "../../constants";
+import {
+  replyMock,
+  sendOpenReplyMock,
+  sendTemplateMessageMock,
+  volunteerPhoneMock,
+} from "../__mocks__/utils";
+import {
+  sendContinueAvailableReply,
+  sendGenericReply,
+  sendNegativeReply,
+  sendPositiveReply,
+  sendUnregistrationReply,
+} from "../replyLogic";
+
+describe("replyLogic", () => {
+  beforeEach(() => {
+    sendOpenReplyMock.mockResolvedValue(replyMock);
+    sendTemplateMessageMock.mockResolvedValue(replyMock);
+  });
+
+  describe("sendGenericReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendGenericReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_GENERIC_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendGenericReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendPositiveReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendPositiveReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_POSITIVE_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendPositiveReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendNegativeReply", () => {
+    it("should call sendTemplateMessag with correct params", async () => {
+      await sendNegativeReply(volunteerPhoneMock);
+
+      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+        volunteerPhoneMock,
+        {}
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendNegativeReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendContinueAvailableReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendContinueAvailableReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendContinueAvailableReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendUnregistrationReply", () => {
+    it("should call sendTemplateMessag with correct params", async () => {
+      await sendUnregistrationReply(volunteerPhoneMock);
+
+      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+        volunteerPhoneMock,
+        {}
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendUnregistrationReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+});

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -1,0 +1,130 @@
+import type { TwilioMessage } from "../../types";
+import {
+  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_GENERIC_REPLY,
+  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+  WHATSAPP_POSITIVE_REPLY,
+  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+} from "../../constants";
+import * as sendOpenReply from "../../twilioClient/sendOpenReply";
+import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
+import {
+  sendContinueAvailableReply,
+  sendGenericReply,
+  sendNegativeReply,
+  sendPositiveReply,
+  sendUnregistrationReply,
+} from "../sendReply";
+
+const volunteerPhoneMock = "5511123456789";
+
+const replyMock = {
+  status: "accepted",
+} as TwilioMessage;
+
+const sendOpenReplyMock = jest
+  .spyOn(sendOpenReply, "default")
+  .mockImplementation(() => Promise.resolve(null));
+
+const sendTemplateMessageMock = jest
+  .spyOn(sendTemplateMessage, "default")
+  .mockImplementation(() => Promise.resolve(null));
+
+describe("sendReply functions", () => {
+  beforeEach(() => {
+    sendOpenReplyMock.mockResolvedValue(replyMock);
+    sendTemplateMessageMock.mockResolvedValue(replyMock);
+  });
+
+  describe("sendGenericReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendGenericReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_GENERIC_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendGenericReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendPositiveReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendPositiveReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_POSITIVE_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendPositiveReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendNegativeReply", () => {
+    it("should call sendTemplateMessag with correct params", async () => {
+      await sendNegativeReply(volunteerPhoneMock);
+
+      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+        volunteerPhoneMock,
+        {}
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendNegativeReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendContinueAvailableReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendContinueAvailableReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendContinueAvailableReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendUnregistrationReply", () => {
+    it("should call sendTemplateMessag with correct params", async () => {
+      await sendUnregistrationReply(volunteerPhoneMock);
+
+      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+        volunteerPhoneMock,
+        {}
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendUnregistrationReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+});

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -1,130 +1,97 @@
-import type { TwilioMessage } from "../../types";
+import * as cleanPhone from "../../utils/cleanPhone";
+import sendReply from "../sendReply";
 import {
-  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
-  WHATSAPP_GENERIC_REPLY,
-  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
-  WHATSAPP_POSITIVE_REPLY,
-  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
-} from "../../constants";
-import * as sendOpenReply from "../../twilioClient/sendOpenReply";
-import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
-import {
-  sendContinueAvailableReply,
-  sendGenericReply,
-  sendNegativeReply,
-  sendPositiveReply,
-  sendUnregistrationReply,
-} from "../sendReply";
+  replyMock,
+  sendOpenReplyMock,
+  sendTemplateMessageMock,
+  volunteerPhoneMock,
+} from "../__mocks__";
+import * as replyLogic from "../replyLogic";
 
-const volunteerPhoneMock = "5511123456789";
+const volunteerFrom = "whatsapp%3A%2B5511123456789";
 
-const replyMock = {
-  status: "accepted",
-} as TwilioMessage;
+const cleanPhoneMock = jest.spyOn(cleanPhone, "default");
 
-const sendOpenReplyMock = jest
-  .spyOn(sendOpenReply, "default")
-  .mockImplementation(() => Promise.resolve(null));
+const sendPositiveReplyMock = jest.spyOn(replyLogic, "sendPositiveReply");
 
-const sendTemplateMessageMock = jest
-  .spyOn(sendTemplateMessage, "default")
-  .mockImplementation(() => Promise.resolve(null));
+const sendNegativeReplyMock = jest.spyOn(replyLogic, "sendNegativeReply");
 
-describe("sendReply functions", () => {
+const sendContinueAvailableReplyMock = jest.spyOn(
+  replyLogic,
+  "sendContinueAvailableReply"
+);
+
+const sendUnregistrationReplyMock = jest.spyOn(
+  replyLogic,
+  "sendUnregistrationReply"
+);
+
+const sendGenericReplyMock = jest.spyOn(replyLogic, "sendGenericReply");
+
+describe("sendReply", () => {
   beforeEach(() => {
     sendOpenReplyMock.mockResolvedValue(replyMock);
     sendTemplateMessageMock.mockResolvedValue(replyMock);
   });
 
-  describe("sendGenericReply", () => {
-    it("should call sendOpenReply with correct params", async () => {
-      await sendGenericReply(volunteerPhoneMock);
+  it("should call cleanPhone with correct params", async () => {
+    await sendReply("button", volunteerFrom, "Sim");
 
-      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
-        1,
-        WHATSAPP_GENERIC_REPLY,
-        volunteerPhoneMock
-      );
-    });
-
-    it("should return the reply that was sent", async () => {
-      const res = await sendGenericReply(volunteerPhoneMock);
-
-      expect(res).toStrictEqual(replyMock);
-    });
+    expect(cleanPhoneMock).toHaveBeenNthCalledWith(1, volunteerFrom);
   });
 
-  describe("sendPositiveReply", () => {
-    it("should call sendOpenReply with correct params", async () => {
-      await sendPositiveReply(volunteerPhoneMock);
+  it("should call sendPositiveReply with correct params", async () => {
+    await sendReply("button", volunteerFrom, "Sim");
 
-      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
-        1,
-        WHATSAPP_POSITIVE_REPLY,
-        volunteerPhoneMock
-      );
-    });
-
-    it("should return the reply that was sent", async () => {
-      const res = await sendPositiveReply(volunteerPhoneMock);
-
-      expect(res).toStrictEqual(replyMock);
-    });
+    expect(sendPositiveReplyMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerPhoneMock
+    );
   });
 
-  describe("sendNegativeReply", () => {
-    it("should call sendTemplateMessag with correct params", async () => {
-      await sendNegativeReply(volunteerPhoneMock);
+  it("should call sendNegativeReply with correct params", async () => {
+    await sendReply("button", volunteerFrom, "Não");
 
-      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
-        1,
-        WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
-        volunteerPhoneMock,
-        {}
-      );
-    });
-
-    it("should return the reply that was sent", async () => {
-      const res = await sendNegativeReply(volunteerPhoneMock);
-
-      expect(res).toStrictEqual(replyMock);
-    });
+    expect(sendNegativeReplyMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerPhoneMock
+    );
   });
 
-  describe("sendContinueAvailableReply", () => {
-    it("should call sendOpenReply with correct params", async () => {
-      await sendContinueAvailableReply(volunteerPhoneMock);
+  it("should call sendContinueAvailableReply with correct params", async () => {
+    await sendReply("interactive", volunteerFrom, "É+um+caso+pontual");
 
-      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
-        1,
-        WHATSAPP_CONTINUE_AVAILABLE_REPLY,
-        volunteerPhoneMock
-      );
-    });
-
-    it("should return the reply that was sent", async () => {
-      const res = await sendContinueAvailableReply(volunteerPhoneMock);
-
-      expect(res).toStrictEqual(replyMock);
-    });
+    expect(sendContinueAvailableReplyMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerPhoneMock
+    );
   });
 
-  describe("sendUnregistrationReply", () => {
-    it("should call sendTemplateMessag with correct params", async () => {
-      await sendUnregistrationReply(volunteerPhoneMock);
+  it("should call sendUnregistrationReply with correct params", async () => {
+    await sendReply("interactive", volunteerFrom, "Quero+descadastrar");
 
-      expect(sendTemplateMessageMock).toHaveBeenNthCalledWith(
-        1,
-        WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
-        volunteerPhoneMock,
-        {}
-      );
-    });
+    expect(sendUnregistrationReplyMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerPhoneMock
+    );
+  });
 
-    it("should return the reply that was sent", async () => {
-      const res = await sendUnregistrationReply(volunteerPhoneMock);
+  it("should call sendGenericReply with correct params", async () => {
+    await sendReply("text", volunteerFrom, "Oi");
 
-      expect(res).toStrictEqual(replyMock);
-    });
+    expect(sendGenericReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
+  });
+
+  it("should return null if the reply wasn't sent", async () => {
+    sendOpenReplyMock.mockResolvedValue(null);
+    const res = await sendReply("text", volunteerFrom, "Oi");
+
+    expect(res).toStrictEqual(null);
+  });
+
+  it("should return the reply that was sent", async () => {
+    const res = await sendReply("text", volunteerFrom, "Oi");
+
+    expect(res).toStrictEqual(replyMock);
   });
 });

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -7,6 +7,7 @@ import {
   volunteerPhoneMock,
 } from "../__mocks__";
 import * as replyLogic from "../replyLogic";
+import { ButtonText } from "../../types";
 
 const volunteerFrom = "whatsapp%3A%2B5511123456789";
 
@@ -35,13 +36,13 @@ describe("sendReply", () => {
   });
 
   it("should call cleanPhone with correct params", async () => {
-    await sendReply("button", volunteerFrom, "Sim");
+    await sendReply(volunteerFrom, ButtonText.positive);
 
     expect(cleanPhoneMock).toHaveBeenNthCalledWith(1, volunteerFrom);
   });
 
   it("should call sendPositiveReply with correct params", async () => {
-    await sendReply("button", volunteerFrom, "Sim");
+    await sendReply(volunteerFrom, ButtonText.positive);
 
     expect(sendPositiveReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -50,7 +51,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendNegativeReply with correct params", async () => {
-    await sendReply("button", volunteerFrom, "Não");
+    await sendReply(volunteerFrom, ButtonText.negative);
 
     expect(sendNegativeReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -59,7 +60,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendContinueAvailableReply with correct params", async () => {
-    await sendReply("interactive", volunteerFrom, "É+um+caso+pontual");
+    await sendReply(volunteerFrom, ButtonText.continue);
 
     expect(sendContinueAvailableReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -68,7 +69,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendUnregistrationReply with correct params", async () => {
-    await sendReply("interactive", volunteerFrom, "Quero+descadastrar");
+    await sendReply(volunteerFrom, ButtonText.unregistration);
 
     expect(sendUnregistrationReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -77,13 +78,13 @@ describe("sendReply", () => {
   });
 
   it("should call sendGenericReply with correct params", async () => {
-    await sendReply("text", volunteerFrom, "Oi");
+    await sendReply(volunteerFrom, undefined);
 
     expect(sendGenericReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
   });
 
   it("should return the reply that was sent", async () => {
-    const res = await sendReply("text", volunteerFrom, "Oi");
+    const res = await sendReply(volunteerFrom, undefined);
 
     expect(res).toStrictEqual(replyMock);
   });

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -82,13 +82,6 @@ describe("sendReply", () => {
     expect(sendGenericReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
   });
 
-  it("should return null if the reply wasn't sent", async () => {
-    sendOpenReplyMock.mockResolvedValue(null);
-    const res = await sendReply("text", volunteerFrom, "Oi");
-
-    expect(res).toStrictEqual(null);
-  });
-
   it("should return the reply that was sent", async () => {
     const res = await sendReply("text", volunteerFrom, "Oi");
 

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -10,11 +10,15 @@ import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
 
 export async function sendGenericReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
+  if (!message || message.status != "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendPositiveReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
+  if (!message || message.status != "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
@@ -25,11 +29,15 @@ export async function sendNegativeReply(phone: string) {
     phone,
     contentVariables
   );
+  if (!message || message.status != "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendContinueAvailableReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
+  if (!message || message.status != "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
@@ -40,5 +48,7 @@ export async function sendUnregistrationReply(phone: string) {
     phone,
     contentVariables
   );
+  if (!message || message.status != "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -1,0 +1,44 @@
+import {
+  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_GENERIC_REPLY,
+  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+  WHATSAPP_POSITIVE_REPLY,
+  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+} from "../constants";
+import sendOpenReply from "../twilioClient/sendOpenReply";
+import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
+
+export async function sendGenericReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
+  return message;
+}
+
+export async function sendPositiveReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
+  return message;
+}
+
+export async function sendNegativeReply(phone: string) {
+  const contentVariables = {};
+  const message = await sendTemplateMessage(
+    WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+    phone,
+    contentVariables
+  );
+  return message;
+}
+
+export async function sendContinueAvailableReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
+  return message;
+}
+
+export async function sendUnregistrationReply(phone: string) {
+  const contentVariables = {};
+  const message = await sendTemplateMessage(
+    WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+    phone,
+    contentVariables
+  );
+  return message;
+}

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -10,14 +10,14 @@ import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
 
 export async function sendGenericReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
-  if (!message || message.status != "accepted")
+  if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendPositiveReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
-  if (!message || message.status != "accepted")
+  if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
@@ -29,14 +29,14 @@ export async function sendNegativeReply(phone: string) {
     phone,
     contentVariables
   );
-  if (!message || message.status != "accepted")
+  if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendContinueAvailableReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
-  if (!message || message.status != "accepted")
+  if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
@@ -48,7 +48,7 @@ export async function sendUnregistrationReply(phone: string) {
     phone,
     contentVariables
   );
-  if (!message || message.status != "accepted")
+  if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }

--- a/src/reply/sendReply.ts
+++ b/src/reply/sendReply.ts
@@ -3,15 +3,15 @@ import {
   NEGATIVE_ANSWER,
   POSITIVE_ANSWER,
   UNREGISTRATION_ANSWER,
-  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
-  WHATSAPP_GENERIC_REPLY,
-  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
-  WHATSAPP_POSITIVE_REPLY,
-  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
 } from "../constants";
-import sendOpenReply from "../twilioClient/sendOpenReply";
-import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
 import { cleanPhone } from "../utils";
+import {
+  sendContinueAvailableReply,
+  sendGenericReply,
+  sendNegativeReply,
+  sendPositiveReply,
+  sendUnregistrationReply,
+} from "./replyLogic";
 
 export default async function sendReply(
   messageType: string,
@@ -43,39 +43,4 @@ export default async function sendReply(
 
   reply = await sendGenericReply(cleanedPhone);
   return reply;
-}
-
-export async function sendGenericReply(phone: string) {
-  const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
-  return message;
-}
-
-export async function sendPositiveReply(phone: string) {
-  const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
-  return message;
-}
-
-export async function sendNegativeReply(phone: string) {
-  const contentVariables = {};
-  const message = await sendTemplateMessage(
-    WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
-    phone,
-    contentVariables
-  );
-  return message;
-}
-
-export async function sendContinueAvailableReply(phone: string) {
-  const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
-  return message;
-}
-
-export async function sendUnregistrationReply(phone: string) {
-  const contentVariables = {};
-  const message = await sendTemplateMessage(
-    WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
-    phone,
-    contentVariables
-  );
-  return message;
 }

--- a/src/reply/sendReply.ts
+++ b/src/reply/sendReply.ts
@@ -45,17 +45,17 @@ export default async function sendReply(
   return reply;
 }
 
-async function sendGenericReply(phone: string) {
+export async function sendGenericReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
   return message;
 }
 
-async function sendPositiveReply(phone: string) {
+export async function sendPositiveReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
   return message;
 }
 
-async function sendNegativeReply(phone: string) {
+export async function sendNegativeReply(phone: string) {
   const contentVariables = {};
   const message = await sendTemplateMessage(
     WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
@@ -65,12 +65,12 @@ async function sendNegativeReply(phone: string) {
   return message;
 }
 
-async function sendContinueAvailableReply(phone: string) {
+export async function sendContinueAvailableReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
   return message;
 }
 
-async function sendUnregistrationReply(phone: string) {
+export async function sendUnregistrationReply(phone: string) {
   const contentVariables = {};
   const message = await sendTemplateMessage(
     WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,

--- a/src/reply/sendReply.ts
+++ b/src/reply/sendReply.ts
@@ -1,0 +1,81 @@
+import {
+  CONTINUE_AVAILABLE_ANSWER,
+  NEGATIVE_ANSWER,
+  POSITIVE_ANSWER,
+  UNREGISTRATION_ANSWER,
+  WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_GENERIC_REPLY,
+  WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+  WHATSAPP_POSITIVE_REPLY,
+  WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+} from "../constants";
+import sendOpenReply from "../twilioClient/sendOpenReply";
+import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
+import { cleanPhone } from "../utils";
+
+export default async function sendReply(
+  messageType: string,
+  phone: string,
+  buttonText: string | undefined
+) {
+  const cleanedPhone = cleanPhone(phone);
+  let reply = null;
+
+  if (messageType === "button") {
+    if (buttonText === POSITIVE_ANSWER)
+      reply = await sendPositiveReply(cleanedPhone);
+
+    if (buttonText === NEGATIVE_ANSWER)
+      reply = await sendNegativeReply(cleanedPhone);
+
+    return reply;
+  }
+
+  if (messageType === "interactive") {
+    if (buttonText === CONTINUE_AVAILABLE_ANSWER)
+      reply = await sendContinueAvailableReply(cleanedPhone);
+
+    if (buttonText === UNREGISTRATION_ANSWER)
+      reply = await sendUnregistrationReply(cleanedPhone);
+
+    return reply;
+  }
+
+  reply = await sendGenericReply(cleanedPhone);
+  return reply;
+}
+
+async function sendGenericReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
+  return message;
+}
+
+async function sendPositiveReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
+  return message;
+}
+
+async function sendNegativeReply(phone: string) {
+  const contentVariables = {};
+  const message = await sendTemplateMessage(
+    WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
+    phone,
+    contentVariables
+  );
+  return message;
+}
+
+async function sendContinueAvailableReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
+  return message;
+}
+
+async function sendUnregistrationReply(phone: string) {
+  const contentVariables = {};
+  const message = await sendTemplateMessage(
+    WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID,
+    phone,
+    contentVariables
+  );
+  return message;
+}

--- a/src/twilioClient/index.ts
+++ b/src/twilioClient/index.ts
@@ -1,0 +1,9 @@
+import twilio from "twilio";
+import { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } from "../constants";
+
+const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+
+export default twilioClient;
+
+export { default as sendOpenReply } from "./sendOpenReply";
+export { default as sendTemplateMessage } from "./sendTemplateMessage";

--- a/src/twilioClient/sendOpenReply.ts
+++ b/src/twilioClient/sendOpenReply.ts
@@ -8,16 +8,14 @@ import twilio from "twilio";
 
 const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
-export default async function createMessage(
-  templateId: string,
-  phone: string,
-  contentVariables: Record<number, string>
+export default async function sendOpenReply(
+  body: string,
+  phone: string
 ): Promise<TwilioMessage | null> {
   const message = await twilioClient.messages.create({
-    contentSid: templateId,
-    contentVariables: JSON.stringify(contentVariables),
     from: WHATSAPP_SENDER_ID,
     to: "whatsapp:+" + phone,
+    body: body,
   });
 
   return message;

--- a/src/twilioClient/sendOpenReply.ts
+++ b/src/twilioClient/sendOpenReply.ts
@@ -1,12 +1,6 @@
-import {
-  TWILIO_ACCOUNT_SID,
-  TWILIO_AUTH_TOKEN,
-  WHATSAPP_SENDER_ID,
-} from "../constants";
+import twilioClient from ".";
+import { WHATSAPP_SENDER_ID } from "../constants";
 import type { TwilioMessage } from "../types/Twilio";
-import twilio from "twilio";
-
-const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
 export default async function sendOpenReply(
   body: string,

--- a/src/twilioClient/sendTemplateMessage.ts
+++ b/src/twilioClient/sendTemplateMessage.ts
@@ -1,0 +1,24 @@
+import {
+  TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN,
+  WHATSAPP_SENDER_ID,
+} from "../constants";
+import type { TwilioMessage } from "../types/Twilio";
+import twilio from "twilio";
+
+const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+
+export default async function sendTemplateMessage(
+  templateId: string,
+  phone: string,
+  contentVariables: Record<number, string> | null
+): Promise<TwilioMessage | null> {
+  const message = await twilioClient.messages.create({
+    contentSid: templateId,
+    contentVariables: JSON.stringify(contentVariables),
+    from: WHATSAPP_SENDER_ID,
+    to: "whatsapp:+" + phone,
+  });
+
+  return message;
+}

--- a/src/twilioClient/sendTemplateMessage.ts
+++ b/src/twilioClient/sendTemplateMessage.ts
@@ -1,12 +1,6 @@
-import {
-  TWILIO_ACCOUNT_SID,
-  TWILIO_AUTH_TOKEN,
-  WHATSAPP_SENDER_ID,
-} from "../constants";
+import twilioClient from ".";
+import { WHATSAPP_SENDER_ID } from "../constants";
 import type { TwilioMessage } from "../types/Twilio";
-import twilio from "twilio";
-
-const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
 export default async function sendTemplateMessage(
   templateId: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,16 @@
+import {
+  CONTINUE_AVAILABLE_ANSWER,
+  NEGATIVE_ANSWER,
+  POSITIVE_ANSWER,
+  UNREGISTRATION_ANSWER,
+} from "../constants";
+
 export * from "./Zendesk";
 export * from "./Twilio";
+
+export enum ButtonText {
+  positive = POSITIVE_ANSWER,
+  negative = NEGATIVE_ANSWER,
+  unregistration = UNREGISTRATION_ANSWER,
+  continue = CONTINUE_AVAILABLE_ANSWER,
+}

--- a/src/utils/__tests__/paramsToJson.spec.ts
+++ b/src/utils/__tests__/paramsToJson.spec.ts
@@ -26,4 +26,16 @@ describe("paramsToJson()", () => {
     const res = paramsToJson(str);
     expect(res).toStrictEqual(json);
   });
+
+  it("should return null if string isn't valid", () => {
+    const str = "a";
+
+    expect(paramsToJson(str)).toStrictEqual(null);
+  });
+
+  it("should return null if string is null", () => {
+    const str = null;
+
+    expect(paramsToJson(str)).toStrictEqual(null);
+  });
 });

--- a/src/utils/__tests__/paramsToJson.spec.ts
+++ b/src/utils/__tests__/paramsToJson.spec.ts
@@ -1,0 +1,29 @@
+import paramsToJson from "../paramsToJson";
+
+describe("paramsToJson()", () => {
+  it("should parse a string with params to a valid json", () => {
+    const str =
+      "SmsMessageSid=SM802c0d39a503aae472cee7379abff9f6&NumMedia=0&ProfileName=Camila+Cardoso&MessageType=text&SmsSid=SM802c0d39a503aae472cee7379abff9f6&WaId=5513997270748&SmsStatus=received&Body=Oi&To=whatsapp%3A%2B551151963407&MessagingServiceSid=MG079062f161fcf64622214b97dfe44e3c&NumSegments=1&ReferralNumMedia=0&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5513997270748&ApiVersion=2010-04-01";
+
+    const json = {
+      SmsMessageSid: "SM802c0d39a503aae472cee7379abff9f6",
+      NumMedia: "0",
+      ProfileName: "Camila+Cardoso",
+      MessageType: "text",
+      SmsSid: "SM802c0d39a503aae472cee7379abff9f6",
+      WaId: "5513997270748",
+      SmsStatus: "received",
+      Body: "Oi",
+      To: "whatsapp%3A%2B551151963407",
+      MessagingServiceSid: "MG079062f161fcf64622214b97dfe44e3c",
+      NumSegments: "1",
+      ReferralNumMedia: "0",
+      MessageSid: "SM802c0d39a503aae472cee7379abff9f6",
+      From: "whatsapp%3A%2B5513997270748",
+      ApiVersion: "2010-04-01",
+    };
+
+    const res = paramsToJson(str);
+    expect(res).toStrictEqual(json);
+  });
+});

--- a/src/utils/__tests__/parseParamsToJson.spec.ts
+++ b/src/utils/__tests__/parseParamsToJson.spec.ts
@@ -1,6 +1,6 @@
-import paramsToJson from "../paramsToJson";
+import { parseParamsToJson } from "../index";
 
-describe("paramsToJson()", () => {
+describe("parseParamsToJson()", () => {
   it("should parse a string with params to a valid json", () => {
     const str =
       "SmsMessageSid=SM802c0d39a503aae472cee7379abff9f6&NumMedia=0&ProfileName=Camila+Cardoso&MessageType=text&SmsSid=SM802c0d39a503aae472cee7379abff9f6&WaId=5513997270748&SmsStatus=received&Body=Oi&To=whatsapp%3A%2B551151963407&MessagingServiceSid=MG079062f161fcf64622214b97dfe44e3c&NumSegments=1&ReferralNumMedia=0&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5513997270748&ApiVersion=2010-04-01";
@@ -23,19 +23,19 @@ describe("paramsToJson()", () => {
       ApiVersion: "2010-04-01",
     };
 
-    const res = paramsToJson(str);
+    const res = parseParamsToJson(str);
     expect(res).toStrictEqual(json);
   });
 
   it("should return null if string isn't valid", () => {
     const str = "a";
 
-    expect(paramsToJson(str)).toStrictEqual(null);
+    expect(parseParamsToJson(str)).toStrictEqual(null);
   });
 
   it("should return null if string is null", () => {
     const str = null;
 
-    expect(paramsToJson(str)).toStrictEqual(null);
+    expect(parseParamsToJson(str)).toStrictEqual(null);
   });
 });

--- a/src/utils/cleanPhone.ts
+++ b/src/utils/cleanPhone.ts
@@ -1,0 +1,3 @@
+export default function cleanPhone(phone: string) {
+  return phone.slice(-13);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,4 +5,5 @@ export { default as isJsonString } from "./isJsonString";
 export { default as isProduction } from "./isProduction";
 export { default as encrypt } from "./encrypt";
 export { default as notFoundErrorPayload } from "./notFoundErrorPayload";
+export { default as parseParamsToJson } from "./parseParamsToJson";
 export * from "./stringfyBigInt";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,4 +6,5 @@ export { default as isProduction } from "./isProduction";
 export { default as encrypt } from "./encrypt";
 export { default as notFoundErrorPayload } from "./notFoundErrorPayload";
 export { default as parseParamsToJson } from "./parseParamsToJson";
+export { default as cleanPhone } from "./cleanPhone";
 export * from "./stringfyBigInt";

--- a/src/utils/paramsToJson.ts
+++ b/src/utils/paramsToJson.ts
@@ -1,11 +1,17 @@
-export default function paramsToJson(str: string) {
-  const parsedStr = JSON.parse(
-    '{"' +
-      decodeURI(str)
-        .replace(/"/g, '\\"')
-        .replace(/&/g, '","')
-        .replace(/=/g, '":"') +
-      '"}'
-  );
-  return parsedStr;
+export default function paramsToJson(str: string | null) {
+  try {
+    if (!str) return null;
+
+    const parsedStr = JSON.parse(
+      '{"' +
+        decodeURI(str)
+          .replace(/"/g, '\\"')
+          .replace(/&/g, '","')
+          .replace(/=/g, '":"') +
+        '"}'
+    );
+    return parsedStr;
+  } catch (e) {
+    return null;
+  }
 }

--- a/src/utils/paramsToJson.ts
+++ b/src/utils/paramsToJson.ts
@@ -1,0 +1,11 @@
+export default function paramsToJson(str: string) {
+  const parsedStr = JSON.parse(
+    '{"' +
+      decodeURI(str)
+        .replace(/"/g, '\\"')
+        .replace(/&/g, '","')
+        .replace(/=/g, '":"') +
+      '"}'
+  );
+  return parsedStr;
+}

--- a/src/utils/parseParamsToJson.ts
+++ b/src/utils/parseParamsToJson.ts
@@ -1,4 +1,4 @@
-export default function paramsToJson(str: string | null) {
+export default function parseParamsToJson(str: string | null) {
   try {
     if (!str) return null;
 

--- a/src/utils/parseParamsToJson.ts
+++ b/src/utils/parseParamsToJson.ts
@@ -2,14 +2,13 @@ export default function parseParamsToJson(str: string | null) {
   try {
     if (!str) return null;
 
-    const parsedStr = JSON.parse(
-      '{"' +
-        decodeURI(str)
-          .replace(/"/g, '\\"')
-          .replace(/&/g, '","')
-          .replace(/=/g, '":"') +
-        '"}'
-    );
+    const decodedStr = decodeURI(str);
+    const replacedStr = decodedStr
+      .replace(/"/g, '\\"')
+      .replace(/&/g, '","')
+      .replace(/=/g, '":"');
+    const parsedStr = JSON.parse(`{"${replacedStr}"}`);
+
     return parsedStr;
   } catch (e) {
     return null;


### PR DESCRIPTION
Esse PR cria o endpoint `/handle-answer' para lidar com a resposta da voluntária após perguntarmos sobre a sua disponibilidade.

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/ff3de436-b779-487b-834c-ff9066998ca4">
