### PR TITLE
feat: adds match denied logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=postgresql://postgres:changeme@localhost:5432/mapa-org?connection_l
 NEW_RELIC_ACCOUNT_ID=
 NEW_RELIC_API_KEY=
 
+LOOPS_API_KEY=
+
 ZENDESK_API_TOKEN=
 ZENDESK_API_USER=
 ZENDESK_SUBDOMAIN=

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -665,7 +665,7 @@ enum MatchConfirmationStatus {
   waiting
   confirmed
   denied
-  failed
+  expired
 
   @@map("match_confirmation_status")
   @@schema("match")

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -1,21 +1,16 @@
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import { handleAnswer } from "../../handler";
 import * as sendReply from "../reply/sendReply";
-import * as processMatchConfirmation from "../matchConfirmation/processMatchConfirmation";
+import * as handleVolunteerAnswer from "../handleVolunteerAnswer/handleVolunteerAnswer";
 import { replyMock } from "../reply/__mocks__";
 
 const callback = jest.fn();
 
 const defaultBody =
   "MessageType=text&Body=Oi&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5511123456789";
-const positiveAnswerBody =
-  "MessageType=button&Body=Sim&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5511123456789&ButtonText=Sim&ButtonPayload=yes_12345";
 
 const sendReplyMock = jest.spyOn(sendReply, "default");
-const processMatchConfirmationMock = jest.spyOn(
-  processMatchConfirmation,
-  "default"
-);
+const handleVolunteerAnswerMock = jest.spyOn(handleVolunteerAnswer, "default");
 
 describe("/handle-answer endpoint", () => {
   it("should return an error res when no body is provided to the req", async () => {
@@ -52,7 +47,7 @@ describe("/handle-answer endpoint", () => {
     });
   });
 
-  it("should call sendReply with correct params", async () => {
+  it("should call handleVolunteerAnswer with correct params", async () => {
     await handleAnswer(
       {
         body: defaultBody,
@@ -61,9 +56,10 @@ describe("/handle-answer endpoint", () => {
       callback
     );
 
-    expect(sendReplyMock).toHaveBeenNthCalledWith(
+    expect(handleVolunteerAnswerMock).toHaveBeenNthCalledWith(
       1,
       "whatsapp%3A%2B5511123456789",
+      undefined,
       undefined
     );
   });
@@ -87,23 +83,6 @@ describe("/handle-answer endpoint", () => {
         error: `Couldn't send whatsapp message to phone: 5511123456789`,
       }),
     });
-  });
-
-  it("should call processMatchConfirmation with correct params when volunteer has answered positively", async () => {
-    sendReplyMock.mockResolvedValueOnce(replyMock);
-    await handleAnswer(
-      {
-        body: positiveAnswerBody,
-      } as APIGatewayProxyEvent,
-      {} as Context,
-      callback
-    );
-
-    expect(processMatchConfirmationMock).toHaveBeenNthCalledWith(
-      1,
-      "Sim",
-      "yes_12345"
-    );
   });
 
   it("should return the reply", async () => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -41,6 +41,7 @@ export const WHATSAPP_POSITIVE_REPLY = `Obrigada por confirmar sua disponibilida
 export const WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID =
   "HX0933a196163d79735d6ec3871672ce14";
 export const WHATSAPP_CONTINUE_AVAILABLE_REPLY = `Obrigada pelo seu retorno! Em breve você receberá outras oportunidades de atendimento. 💜`;
+export const WHATSAPP_ERROR_REPLY = `Ops, parece que essa solicitação já foi processada. Se estiver enfrentando alguma dificuldade, por favor, entre em contato pelo e-mail: voluntaria@mapadoacolhimento.org`;
 export const WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID =
   "HX3ccc5212f22ecc0dbb2d27096374fb2c";
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,8 +13,11 @@ export const ZENDESK_CUSTOM_FIELDS_DICIO = {
 
 export const ZENDESK_TICKET_WAITING_FOR_CONFIRMATION_STATUS =
   "encaminhamento__aguardando_confirmação";
+export const ZENDESK_TICKET_WAITING_FOR_MATCH_STATUS =
+  "aguardando_match__sem_prioridade";
 export const ZENDESK_USER_WAITING_FOR_CONFIRMATION_STATUS =
   "indisponivel_aguardando_confirmacao";
+export const ZENDESK_USER_AVAILABLE_STATUS = "disponivel";
 
 // TWILIO
 export const TWILIO_ACCOUNT_SID = process.env["TWILIO_ACCOUNT_SID"];
@@ -46,3 +49,6 @@ export const POSITIVE_ANSWER = "Sim";
 export const NEGATIVE_ANSWER = "Não";
 export const CONTINUE_AVAILABLE_ANSWER = "É+um+caso+pontual";
 export const UNREGISTRATION_ANSWER = "Quero+descadastrar";
+
+// LOOPS
+export const MSR_EMAIL_TRANSACTION_ID = "clzspeh8m00jw10mfp8yl96ih";

--- a/src/emailClient/__tests__/index.spec.ts
+++ b/src/emailClient/__tests__/index.spec.ts
@@ -1,8 +1,14 @@
 import { sendEmailToMsr } from "..";
 import { MSR_EMAIL_TRANSACTION_ID } from "../../constants";
 import * as sendEmail from "../../emailClient/sendEmail";
+import { supportRequestMock } from "../../matchConfirmation/__mocks__";
 
 const sendEmailMock = jest.spyOn(sendEmail, "default");
+
+const msrPiiMock = {
+  email: "msr@gmail.com",
+  firstName: "MSR",
+};
 
 describe("sendEmailToMsr", () => {
   beforeEach(() => {
@@ -10,7 +16,7 @@ describe("sendEmailToMsr", () => {
   });
 
   it("should call sendEmail with correct params", async () => {
-    const res = await sendEmailToMsr("msr@gmail.com", "MSR");
+    const res = await sendEmailToMsr(msrPiiMock, supportRequestMock);
     expect(res).toStrictEqual(true);
     expect(sendEmailMock).toHaveBeenNthCalledWith(
       1,
@@ -18,6 +24,8 @@ describe("sendEmailToMsr", () => {
       MSR_EMAIL_TRANSACTION_ID,
       {
         msr_first_name: "MSR",
+        support_request_id: supportRequestMock.supportRequestId.toString(),
+        volunteer_type: "advogada",
       }
     );
   });

--- a/src/emailClient/__tests__/index.spec.ts
+++ b/src/emailClient/__tests__/index.spec.ts
@@ -1,0 +1,24 @@
+import { sendEmailToMsr } from "..";
+import { MSR_EMAIL_TRANSACTION_ID } from "../../constants";
+import * as sendEmail from "../../emailClient/sendEmail";
+
+const sendEmailMock = jest.spyOn(sendEmail, "default");
+
+describe("sendEmailToMsr", () => {
+  beforeEach(() => {
+    sendEmailMock.mockResolvedValueOnce(true);
+  });
+
+  it("should call sendEmail with correct params", async () => {
+    const res = await sendEmailToMsr("msr@gmail.com", "MSR");
+    expect(res).toStrictEqual(true);
+    expect(sendEmailMock).toHaveBeenNthCalledWith(
+      1,
+      "msr@gmail.com",
+      MSR_EMAIL_TRANSACTION_ID,
+      {
+        msr_first_name: "MSR",
+      }
+    );
+  });
+});

--- a/src/emailClient/index.ts
+++ b/src/emailClient/index.ts
@@ -1,12 +1,23 @@
+import type { MSRPiiSec, SupportRequests } from "@prisma/client";
 import { MSR_EMAIL_TRANSACTION_ID } from "../constants";
 import sendEmail from "./sendEmail";
 
-export async function sendEmailToMsr(email: string, firstName: string) {
+export async function sendEmailToMsr(
+  msr: Pick<MSRPiiSec, "email" | "firstName">,
+  supportRequest: Pick<SupportRequests, "supportRequestId" | "supportType">
+) {
   const emailVars = {
-    msr_first_name: firstName,
+    msr_first_name: msr.firstName || "Acolhida",
+    support_request_id: supportRequest.supportRequestId.toString(),
+    volunteer_type:
+      supportRequest.supportType === "legal" ? "advogada" : "psicóloga",
   };
 
-  const emailRes = await sendEmail(email, MSR_EMAIL_TRANSACTION_ID, emailVars);
+  const emailRes = await sendEmail(
+    msr.email,
+    MSR_EMAIL_TRANSACTION_ID,
+    emailVars
+  );
 
   return emailRes;
 }

--- a/src/emailClient/index.ts
+++ b/src/emailClient/index.ts
@@ -1,0 +1,12 @@
+import { MSR_EMAIL_TRANSACTION_ID } from "../constants";
+import sendEmail from "./sendEmail";
+
+export async function sendEmailToMsr(email: string, firstName: string) {
+  const emailVars = {
+    msr_first_name: firstName,
+  };
+
+  const emailRes = await sendEmail(email, MSR_EMAIL_TRANSACTION_ID, emailVars);
+
+  return emailRes;
+}

--- a/src/emailClient/sendEmail.ts
+++ b/src/emailClient/sendEmail.ts
@@ -1,0 +1,40 @@
+import { getErrorMessage } from "../utils";
+
+export default async function sendEmail(
+  email: string,
+  id: string,
+  emailVars: Record<string, string>
+): Promise<boolean> {
+  try {
+    const endpoint = "https://app.loops.so/api/v1/transactional";
+    const apiKey = process.env["LOOPS_API_KEY"];
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        email,
+        transactionalId: id,
+        dataVariables: {
+          ...emailVars,
+        },
+      }),
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+
+    return response.ok;
+  } catch (e) {
+    console.error(
+      `[sendEmail] - Something went wrong when sending an email to this email '${email}', with this transactionalId: '${id}': ${getErrorMessage(
+        e
+      )}`
+    );
+    return false;
+  }
+}

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -5,14 +5,13 @@ import type {
 } from "aws-lambda";
 import { object, string } from "yup";
 import { getErrorMessage, stringfyBigInt, parseParamsToJson } from "./utils";
-import sendReply from "./reply/sendReply";
-import { ButtonText } from "./types";
-import processMatchConfirmation from "./matchConfirmation/processMatchConfirmation";
+import handleVolunteerAnswer from "./handleVolunteerAnswer/handleVolunteerAnswer";
+import { ReplyType } from "./types";
 
 const bodySchema = object({
   MessageSid: string().required(),
   From: string().required(),
-  ButtonText: string().oneOf(Object.values(ButtonText)),
+  ButtonText: string().oneOf(Object.values(ReplyType)),
   ButtonPayload: string(),
 }).required();
 
@@ -36,10 +35,7 @@ export default async function handler(
       ButtonPayload: buttonPayload,
     } = validatedBody;
 
-    const reply = await sendReply(from, buttonText);
-
-    if (buttonText && buttonPayload)
-      await processMatchConfirmation(buttonText, buttonPayload);
+    const reply = await handleVolunteerAnswer(from, buttonText, buttonPayload);
 
     const bodyRes = JSON.stringify({
       message: stringfyBigInt(reply),

--- a/src/handleVolunteerAnswer/__tests__/handleVolunteerAnswer.spec.ts
+++ b/src/handleVolunteerAnswer/__tests__/handleVolunteerAnswer.spec.ts
@@ -1,0 +1,139 @@
+import handleVolunteerAnswer from "../handleVolunteerAnswer";
+import { ReplyType } from "../../types";
+import { prismaMock } from "../../setupTests";
+import {
+  matchConfirmationMock,
+  supportRequestMock,
+  volunteerMock,
+} from "../../matchConfirmation/__mocks__";
+import { replyMock } from "../../reply/__mocks__";
+import * as confirmationLogic from "../../matchConfirmation/matchConfirmationLogic";
+import * as utils from "../../utils";
+import * as sendReply from "../../reply/sendReply";
+import * as processMatchConfirmation from "../../matchConfirmation/processMatchConfirmation";
+
+const volunteerFrom = "whatsapp%3A%2B5511123456789";
+const buttonTextMock = "Sim" as ReplyType;
+const buttonPayloadMock = "yes_12345";
+
+const getMatchConfirmationIdMock = jest.spyOn(
+  confirmationLogic,
+  "getMatchConfirmationId"
+);
+const fetchMatchConfirmationMock = jest.spyOn(
+  confirmationLogic,
+  "fetchMatchConfirmation"
+);
+const cleanPhoneMock = jest.spyOn(utils, "cleanPhone");
+const sendReplyMock = jest.spyOn(sendReply, "default");
+const processMatchConfirmationMock = jest
+  .spyOn(processMatchConfirmation, "default")
+  .mockImplementation(() => Promise.resolve(matchConfirmationMock));
+
+describe("handleVolunteerAnswer", () => {
+  beforeEach(() => {
+    sendReplyMock.mockResolvedValueOnce(replyMock);
+    prismaMock.matchConfirmations.findUnique.mockResolvedValue(
+      matchConfirmationMock
+    );
+    prismaMock.supportRequests.findUniqueOrThrow.mockResolvedValue(
+      supportRequestMock
+    );
+    prismaMock.volunteers.findUniqueOrThrow.mockResolvedValue(volunteerMock);
+    processMatchConfirmationMock.mockResolvedValue(matchConfirmationMock);
+  });
+
+  it("should call cleanPhone with correct params", async () => {
+    await handleVolunteerAnswer(
+      volunteerFrom,
+      buttonTextMock,
+      buttonPayloadMock
+    );
+
+    expect(cleanPhoneMock).toHaveBeenNthCalledWith(1, volunteerFrom);
+  });
+
+  describe("when it doesn't need to process the match confirmation", () => {
+    it("should call sendReply with correct params", async () => {
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        ReplyType.unregistration,
+        undefined
+      );
+
+      expect(sendReplyMock).toHaveBeenNthCalledWith(
+        1,
+        "5511123456789",
+        ReplyType.unregistration
+      );
+    });
+  });
+
+  describe("when it needs to process the match confirmation", () => {
+    it("should call getMatchConfirmationId with correct params", async () => {
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        buttonTextMock,
+        buttonPayloadMock
+      );
+
+      expect(getMatchConfirmationIdMock).toHaveBeenNthCalledWith(
+        1,
+        buttonPayloadMock
+      );
+    });
+
+    it("should call fetchMatchConfirmation with correct params", async () => {
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        buttonTextMock,
+        buttonPayloadMock
+      );
+
+      expect(fetchMatchConfirmationMock).toHaveBeenNthCalledWith(1, 12345);
+    });
+
+    it("should call sendReply with correct params when matchConfirmation was not found", async () => {
+      prismaMock.matchConfirmations.findUnique.mockResolvedValue(null);
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        buttonTextMock,
+        buttonPayloadMock
+      );
+
+      expect(sendReplyMock).toHaveBeenNthCalledWith(
+        1,
+        "5511123456789",
+        ReplyType.error
+      );
+    });
+
+    it("should call sendReply with correct params when matchConfirmation was found", async () => {
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        buttonTextMock,
+        buttonPayloadMock
+      );
+
+      expect(sendReplyMock).toHaveBeenNthCalledWith(
+        1,
+        "5511123456789",
+        ReplyType.positive
+      );
+    });
+
+    it("should call processMatchConfirmation with correct params", async () => {
+      await handleVolunteerAnswer(
+        volunteerFrom,
+        buttonTextMock,
+        buttonPayloadMock
+      );
+
+      expect(processMatchConfirmationMock).toHaveBeenNthCalledWith(
+        1,
+        matchConfirmationMock,
+        ReplyType.positive
+      );
+    });
+  });
+});

--- a/src/handleVolunteerAnswer/handleVolunteerAnswer.ts
+++ b/src/handleVolunteerAnswer/handleVolunteerAnswer.ts
@@ -1,0 +1,40 @@
+import {
+  fetchMatchConfirmation,
+  getMatchConfirmationId,
+} from "../matchConfirmation/matchConfirmationLogic";
+import processMatchConfirmation from "../matchConfirmation/processMatchConfirmation";
+import sendReply from "../reply/sendReply";
+
+import { ReplyType } from "../types";
+import { cleanPhone } from "../utils";
+
+export default async function handleVolunteerAnswer(
+  from: string,
+  buttonText?: ReplyType,
+  buttonPayload?: string
+) {
+  const phone = cleanPhone(from);
+
+  const shouldProcessMatchConfirmation =
+    !!buttonPayload &&
+    (buttonText === ReplyType.positive || buttonText === ReplyType.negative);
+
+  if (!shouldProcessMatchConfirmation) {
+    const reply = await sendReply(phone, buttonText);
+    return reply;
+  }
+
+  const matchConfirmationId = getMatchConfirmationId(buttonPayload);
+  const matchConfirmation = await fetchMatchConfirmation(matchConfirmationId);
+
+  if (!matchConfirmation) {
+    const reply = await sendReply(phone, ReplyType.error);
+    return reply;
+  }
+
+  const reply = await sendReply(phone, buttonText);
+
+  await processMatchConfirmation(matchConfirmation, buttonText);
+
+  return reply;
+}

--- a/src/matchConfirmation/__mocks__/utils.ts
+++ b/src/matchConfirmation/__mocks__/utils.ts
@@ -19,6 +19,7 @@ export const supportRequestMock = {
   supportRequestId: 1,
   msrId: 12345 as unknown as bigint,
   zendeskTicketId: 1 as unknown as bigint,
+  supportType: "legal",
   status: "waiting_for_confirmation" as SupportRequestsStatus,
 } as SupportRequests;
 

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -245,7 +245,7 @@ export function getMatchConfirmationId(buttonPayload: string) {
 }
 
 export async function fetchMatchConfirmation(matchConfirmationId: number) {
-  const matchConfirmation = await client.matchConfirmations.findUniqueOrThrow({
+  const matchConfirmation = await client.matchConfirmations.findUnique({
     where: {
       matchConfirmationId: matchConfirmationId,
       status: "waiting",

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -40,6 +40,7 @@ export async function fetchSupportRequestAndVolunteer(
       supportRequestId: true,
       msrId: true,
       zendeskTicketId: true,
+      supportType: true,
       city: true,
       state: true,
     },

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -252,6 +252,7 @@ export async function fetchMatchConfirmation(matchConfirmationId: number) {
     },
     select: {
       matchConfirmationId: true,
+      msrId: true,
       supportRequestId: true,
       volunteerId: true,
       matchType: true,

--- a/src/matchConfirmation/processMatchConfirmation.ts
+++ b/src/matchConfirmation/processMatchConfirmation.ts
@@ -1,31 +1,33 @@
+import type { MatchConfirmations } from "@prisma/client";
 import acceptMatch from "../matchAccepted/acceptMatch";
 import denyMatch from "../matchDenied/denyMatch";
-
-import { ButtonText } from "../types";
-import {
-  fetchSupportRequestAndVolunteer,
-  fetchMatchConfirmation,
-  getMatchConfirmationId,
-} from "./matchConfirmationLogic";
+import { ReplyType } from "../types";
+import { fetchSupportRequestAndVolunteer } from "./matchConfirmationLogic";
 
 export default async function processMatchConfirmation(
-  buttonText: ButtonText,
-  buttonPayload: string
+  matchConfirmation: Pick<
+    MatchConfirmations,
+    | "matchConfirmationId"
+    | "msrId"
+    | "supportRequestId"
+    | "volunteerId"
+    | "matchType"
+    | "matchStage"
+  >,
+  buttonText: ReplyType.positive | ReplyType.negative
 ) {
-  const matchConfirmationId = getMatchConfirmationId(buttonPayload);
-  const matchConfirmation = await fetchMatchConfirmation(matchConfirmationId);
-
   const { supportRequest, volunteer } = await fetchSupportRequestAndVolunteer(
     matchConfirmation.supportRequestId,
     matchConfirmation.volunteerId
   );
 
-  const shouldAcceptMatch =
-    !!buttonPayload && buttonText === ButtonText.positive;
-  if (shouldAcceptMatch)
+  const shouldAcceptMatch = buttonText === ReplyType.positive;
+  if (shouldAcceptMatch) {
     await acceptMatch(matchConfirmation, supportRequest, volunteer);
+    return matchConfirmation;
+  }
 
-  const shouldDenyMatch = !!buttonPayload && buttonText === ButtonText.negative;
-  if (shouldDenyMatch)
-    await denyMatch(matchConfirmation, supportRequest, volunteer);
+  await denyMatch(matchConfirmation, supportRequest, volunteer);
+
+  return matchConfirmation;
 }

--- a/src/matchConfirmation/processMatchConfirmation.ts
+++ b/src/matchConfirmation/processMatchConfirmation.ts
@@ -1,4 +1,5 @@
 import acceptMatch from "../matchAccepted/acceptMatch";
+import denyMatch from "../matchDenied/denyMatch";
 
 import { ButtonText } from "../types";
 import {
@@ -23,4 +24,8 @@ export default async function processMatchConfirmation(
     !!buttonPayload && buttonText === ButtonText.positive;
   if (shouldAcceptMatch)
     await acceptMatch(matchConfirmation, supportRequest, volunteer);
+
+  const shouldDenyMatch = !!buttonPayload && buttonText === ButtonText.negative;
+  if (shouldDenyMatch)
+    await denyMatch(matchConfirmation, supportRequest, volunteer);
 }

--- a/src/matchDenied/__tests__/denyMatch.spec.ts
+++ b/src/matchDenied/__tests__/denyMatch.spec.ts
@@ -1,0 +1,141 @@
+import * as matchDeniedLogic from "../matchDeniedLogic";
+import {
+  matchConfirmationMock,
+  msrZendeskTicketMock,
+  supportRequestMock,
+  updatedUserMock,
+  updateTicketMock,
+  updateUserMock,
+  volunteerMock,
+} from "../../matchConfirmation/__mocks__";
+import denyMatch from "../denyMatch";
+import { prismaMock } from "../../setupTests";
+import type { MSRPiiSec } from "@prisma/client";
+import * as emailClient from "../../emailClient";
+
+const updateTicketWithDenialMock = jest.spyOn(
+  matchDeniedLogic,
+  "updateTicketWithDenial"
+);
+const denyMatchConfirmationMock = jest.spyOn(
+  matchDeniedLogic,
+  "denyMatchConfirmation"
+);
+const addSupportRequestToQueueMock = jest.spyOn(
+  matchDeniedLogic,
+  "addSupportRequestToQueue"
+);
+
+const makeVolunteerAvailableMock = jest.spyOn(
+  matchDeniedLogic,
+  "makeVolunteerAvailable"
+);
+
+const checkPreviousMatchConfirmationsMock = jest.spyOn(
+  matchDeniedLogic,
+  "checkPreviousMatchConfirmations"
+);
+
+const fetchMsrPiiMock = jest.spyOn(matchDeniedLogic, "fetchMsrPii");
+
+const sendEmailToMsrMock = jest
+  .spyOn(emailClient, "sendEmailToMsr")
+  .mockImplementation(() => Promise.resolve(true));
+
+const msrPIIMock = {
+  email: "msr@gmail.com",
+  firstName: "MSR",
+} as MSRPiiSec;
+
+describe("denyMatch", () => {
+  beforeEach(() => {
+    updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
+    updateUserMock.mockResolvedValueOnce(updatedUserMock);
+    prismaMock.mSRPiiSec.findUniqueOrThrow.mockResolvedValueOnce(msrPIIMock);
+  });
+
+  it("should call updateTicketWithDenial with correct params", async () => {
+    await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+    expect(updateTicketWithDenialMock).toHaveBeenNthCalledWith(
+      1,
+      supportRequestMock.zendeskTicketId,
+      volunteerMock
+    );
+  });
+
+  it("should call denyMatchConfirmation with correct params", async () => {
+    await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+    expect(denyMatchConfirmationMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.matchConfirmationId
+    );
+  });
+
+  it("should call addSupportRequestToQueue with correct params", async () => {
+    await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+    expect(addSupportRequestToQueueMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.supportRequestId
+    );
+  });
+
+  it("should call makeVolunteerAvailable with correct params", async () => {
+    await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+    expect(makeVolunteerAvailableMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerMock
+    );
+  });
+
+  it("should call checkPreviousMatchConfirmations with correct params", async () => {
+    await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+    expect(checkPreviousMatchConfirmationsMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.supportRequestId
+    );
+  });
+
+  describe("should send email to MSR if she doesn't have previous match confirmations", () => {
+    it("should call fetchMsrPii with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(false);
+      await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+      expect(fetchMsrPiiMock).toHaveBeenNthCalledWith(
+        1,
+        matchConfirmationMock.msrId
+      );
+    });
+
+    it("should call sendEmailToMsr with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(false);
+      await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+      expect(sendEmailToMsrMock).toHaveBeenNthCalledWith(
+        1,
+        msrPIIMock.email,
+        msrPIIMock.firstName
+      );
+    });
+  });
+
+  describe("should not send email to MSR if she has previous match confirmations", () => {
+    it("should not call fetchMsrPii", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(true);
+      await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+      expect(fetchMsrPiiMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("should call sendEmailToMsr with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(true);
+      await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
+
+      expect(sendEmailToMsrMock).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/matchDenied/__tests__/denyMatch.spec.ts
+++ b/src/matchDenied/__tests__/denyMatch.spec.ts
@@ -96,7 +96,7 @@ describe("denyMatch", () => {
 
     expect(checkPreviousMatchConfirmationsMock).toHaveBeenNthCalledWith(
       1,
-      matchConfirmationMock.supportRequestId
+      matchConfirmationMock
     );
   });
 

--- a/src/matchDenied/__tests__/denyMatch.spec.ts
+++ b/src/matchDenied/__tests__/denyMatch.spec.ts
@@ -131,7 +131,7 @@ describe("denyMatch", () => {
       expect(fetchMsrPiiMock).toHaveBeenCalledTimes(0);
     });
 
-    it("should call sendEmailToMsr with correct params", async () => {
+    it("should not call sendEmailToMsr with correct params", async () => {
       checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(true);
       await denyMatch(matchConfirmationMock, supportRequestMock, volunteerMock);
 

--- a/src/matchDenied/__tests__/denyMatch.spec.ts
+++ b/src/matchDenied/__tests__/denyMatch.spec.ts
@@ -117,8 +117,8 @@ describe("denyMatch", () => {
 
       expect(sendEmailToMsrMock).toHaveBeenNthCalledWith(
         1,
-        msrPIIMock.email,
-        msrPIIMock.firstName
+        msrPIIMock,
+        supportRequestMock
       );
     });
   });

--- a/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
+++ b/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
@@ -1,0 +1,95 @@
+import {
+  matchConfirmationMock,
+  msrZendeskTicketMock,
+  supportRequestMock,
+  updatedUserMock,
+  updateTicketMock,
+  updateUserMock,
+  volunteerAvailabilityMock,
+  volunteerMock,
+} from "../../matchConfirmation/__mocks__";
+import { prismaMock } from "../../setupTests";
+import {
+  checkPreviousMatchConfirmations,
+  makeVolunteerAvailable,
+  updateTicketWithDenial,
+} from "../matchDeniedLogic";
+
+describe("updateTicketWithDenial", () => {
+  it("should call updateTicket with correct params", async () => {
+    updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
+
+    await updateTicketWithDenial(
+      supportRequestMock.zendeskTicketId,
+      volunteerMock
+    );
+
+    expect(updateTicketMock).toHaveBeenNthCalledWith(1, {
+      id: supportRequestMock.zendeskTicketId,
+      custom_fields: [
+        {
+          id: 360014379412,
+          value: "aguardando_match__sem_prioridade",
+        },
+      ],
+      comment: {
+        body: `A [Voluntária ${volunteerMock.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteerMock.zendeskUserId}) negou o match.\n\nO pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
+        public: false,
+      },
+    });
+  });
+
+  it("should throw an error if no ticket was updated on Zendesk", async () => {
+    updateTicketMock.mockResolvedValueOnce(null);
+
+    await expect(
+      updateTicketWithDenial(supportRequestMock.zendeskTicketId, volunteerMock)
+    ).rejects.toThrow("Couldn't update msr Zendesk ticket");
+  });
+});
+
+describe("makeVolunteerAvailable", () => {
+  it("should throw an error if no volunteer was updated on Zendesk", async () => {
+    updateUserMock.mockResolvedValueOnce(null);
+
+    await expect(makeVolunteerAvailable(volunteerMock)).rejects.toThrow(
+      "Couldn't update volunteer Zendesk status"
+    );
+  });
+
+  it("should update volunteer condition to disponivel and return this entry", async () => {
+    updateUserMock.mockResolvedValueOnce(updatedUserMock);
+    prismaMock.volunteers.update.mockResolvedValue(volunteerMock);
+    prismaMock.volunteerAvailability.update.mockResolvedValue(
+      volunteerAvailabilityMock
+    );
+
+    const res = await makeVolunteerAvailable(volunteerMock);
+
+    expect(res).toStrictEqual(volunteerMock);
+  });
+});
+
+describe("checkPreviousMatchConfirmations", () => {
+  it("should true if support_request has previous match confirmations", async () => {
+    prismaMock.matchConfirmations.findMany.mockResolvedValueOnce([
+      matchConfirmationMock,
+    ]);
+
+    const res = await checkPreviousMatchConfirmations(
+      supportRequestMock.supportRequestId
+    );
+
+    expect(res).toStrictEqual(true);
+  });
+
+  it("should false if support_request doesn't have previous match confirmations", async () => {
+    prismaMock.matchConfirmations.findMany.mockResolvedValueOnce([]);
+
+    const res = await checkPreviousMatchConfirmations(
+      supportRequestMock.supportRequestId
+    );
+
+    expect(res).toStrictEqual(false);
+  });
+});

--- a/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
+++ b/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
@@ -76,9 +76,7 @@ describe("checkPreviousMatchConfirmations", () => {
       matchConfirmationMock,
     ]);
 
-    const res = await checkPreviousMatchConfirmations(
-      supportRequestMock.supportRequestId
-    );
+    const res = await checkPreviousMatchConfirmations(matchConfirmationMock);
 
     expect(res).toStrictEqual(true);
   });
@@ -86,9 +84,7 @@ describe("checkPreviousMatchConfirmations", () => {
   it("should return false if support_request doesn't have previous match confirmations", async () => {
     prismaMock.matchConfirmations.findMany.mockResolvedValueOnce([]);
 
-    const res = await checkPreviousMatchConfirmations(
-      supportRequestMock.supportRequestId
-    );
+    const res = await checkPreviousMatchConfirmations(matchConfirmationMock);
 
     expect(res).toStrictEqual(false);
   });

--- a/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
+++ b/src/matchDenied/__tests__/matchDeniedLogic.spec.ts
@@ -71,7 +71,7 @@ describe("makeVolunteerAvailable", () => {
 });
 
 describe("checkPreviousMatchConfirmations", () => {
-  it("should true if support_request has previous match confirmations", async () => {
+  it("should return true if support_request has previous match confirmations", async () => {
     prismaMock.matchConfirmations.findMany.mockResolvedValueOnce([
       matchConfirmationMock,
     ]);
@@ -83,7 +83,7 @@ describe("checkPreviousMatchConfirmations", () => {
     expect(res).toStrictEqual(true);
   });
 
-  it("should false if support_request doesn't have previous match confirmations", async () => {
+  it("should return false if support_request doesn't have previous match confirmations", async () => {
     prismaMock.matchConfirmations.findMany.mockResolvedValueOnce([]);
 
     const res = await checkPreviousMatchConfirmations(

--- a/src/matchDenied/denyMatch.ts
+++ b/src/matchDenied/denyMatch.ts
@@ -32,9 +32,8 @@ export default async function denyMatch(
 
   await makeVolunteerAvailable(volunteer);
 
-  const hasPreviousMatchConfirmations = await checkPreviousMatchConfirmations(
-    matchConfirmation.supportRequestId
-  );
+  const hasPreviousMatchConfirmations =
+    await checkPreviousMatchConfirmations(matchConfirmation);
 
   if (!hasPreviousMatchConfirmations) {
     const msrPii = await fetchMsrPii(matchConfirmation.msrId);

--- a/src/matchDenied/denyMatch.ts
+++ b/src/matchDenied/denyMatch.ts
@@ -18,7 +18,10 @@ export default async function denyMatch(
     MatchConfirmations,
     "matchConfirmationId" | "supportRequestId" | "volunteerId" | "msrId"
   >,
-  supportRequest: Pick<SupportRequests, "zendeskTicketId">,
+  supportRequest: Pick<
+    SupportRequests,
+    "supportRequestId" | "supportType" | "zendeskTicketId"
+  >,
   volunteer: Pick<Volunteers, "id" | "firstName" | "zendeskUserId">
 ) {
   await updateTicketWithDenial(supportRequest.zendeskTicketId, volunteer);
@@ -35,8 +38,7 @@ export default async function denyMatch(
 
   if (!hasPreviousMatchConfirmations) {
     const msrPii = await fetchMsrPii(matchConfirmation.msrId);
-    const msrFirstName = msrPii.firstName || "Acolhida";
 
-    await sendEmailToMsr(msrPii.email, msrFirstName);
+    await sendEmailToMsr(msrPii, supportRequest);
   }
 }

--- a/src/matchDenied/denyMatch.ts
+++ b/src/matchDenied/denyMatch.ts
@@ -29,11 +29,11 @@ export default async function denyMatch(
 
   await makeVolunteerAvailable(volunteer);
 
-  const shouldSendEmailToMsr = await checkPreviousMatchConfirmations(
+  const hasPreviousMatchConfirmations = await checkPreviousMatchConfirmations(
     matchConfirmation.supportRequestId
   );
 
-  if (shouldSendEmailToMsr) {
+  if (!hasPreviousMatchConfirmations) {
     const msrPii = await fetchMsrPii(matchConfirmation.msrId);
     const msrFirstName = msrPii.firstName || "Acolhida";
 

--- a/src/matchDenied/denyMatch.ts
+++ b/src/matchDenied/denyMatch.ts
@@ -1,0 +1,42 @@
+import type {
+  MatchConfirmations,
+  SupportRequests,
+  Volunteers,
+} from "@prisma/client";
+import {
+  addSupportRequestToQueue,
+  checkPreviousMatchConfirmations,
+  denyMatchConfirmation,
+  fetchMsrPii,
+  makeVolunteerAvailable,
+  updateTicketWithDenial,
+} from "./matchDeniedLogic";
+import { sendEmailToMsr } from "../emailClient";
+
+export default async function denyMatch(
+  matchConfirmation: Pick<
+    MatchConfirmations,
+    "matchConfirmationId" | "supportRequestId" | "volunteerId" | "msrId"
+  >,
+  supportRequest: Pick<SupportRequests, "zendeskTicketId">,
+  volunteer: Pick<Volunteers, "id" | "firstName" | "zendeskUserId">
+) {
+  await updateTicketWithDenial(supportRequest.zendeskTicketId, volunteer);
+
+  await denyMatchConfirmation(matchConfirmation.matchConfirmationId);
+
+  await addSupportRequestToQueue(matchConfirmation.supportRequestId);
+
+  await makeVolunteerAvailable(volunteer);
+
+  const shouldSendEmailToMsr = await checkPreviousMatchConfirmations(
+    matchConfirmation.supportRequestId
+  );
+
+  if (shouldSendEmailToMsr) {
+    const msrPii = await fetchMsrPii(matchConfirmation.msrId);
+    const msrFirstName = msrPii.firstName || "Acolhida";
+
+    await sendEmailToMsr(msrPii.email, msrFirstName);
+  }
+}

--- a/src/matchDenied/matchDeniedLogic.ts
+++ b/src/matchDenied/matchDeniedLogic.ts
@@ -42,9 +42,7 @@ export async function updateTicketWithDenial(
       },
     ],
     comment: {
-      body: `A [Voluntária ${volunteer.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteer.zendeskUserId}) negou o match.
-            
-            O pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
+      body: `A [Voluntária ${volunteer.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteer.zendeskUserId}) negou o match.\n\nO pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
       public: false,
     },
   };
@@ -88,7 +86,7 @@ export async function makeVolunteerAvailable(
       `Couldn't update volunteer Zendesk status for zendesk_user_id: ${volunteer.zendeskUserId} `
     );
 
-  await client.volunteers.update({
+  const updatedVolunteer = await client.volunteers.update({
     where: {
       id: volunteer.id,
     },
@@ -115,6 +113,8 @@ export async function makeVolunteerAvailable(
       updated_at: new Date().toISOString(),
     },
   });
+
+  return updatedVolunteer;
 }
 
 export async function checkPreviousMatchConfirmations(
@@ -139,6 +139,10 @@ export async function fetchMsrPii(msrId: bigint) {
   const msrPii = client.mSRPiiSec.findUniqueOrThrow({
     where: {
       msrId: msrId,
+    },
+    select: {
+      email: true,
+      firstName: true,
     },
   });
 

--- a/src/matchDenied/matchDeniedLogic.ts
+++ b/src/matchDenied/matchDeniedLogic.ts
@@ -1,0 +1,146 @@
+import type { Volunteers } from "@prisma/client";
+import type { ZendeskUser } from "../types";
+import updateTicket from "../zendeskClient/updateTicket";
+import client from "../prismaClient";
+import {
+  ZENDESK_CUSTOM_FIELDS_DICIO,
+  ZENDESK_TICKET_WAITING_FOR_MATCH_STATUS,
+  ZENDESK_USER_AVAILABLE_STATUS,
+} from "../constants";
+import updateUser from "../zendeskClient/updateUser";
+
+export async function denyMatchConfirmation(matchConfirmationId: number) {
+  await client.matchConfirmations.update({
+    where: {
+      matchConfirmationId: matchConfirmationId,
+    },
+    data: {
+      status: "denied",
+      updatedAt: new Date().toISOString(),
+    },
+  });
+
+  await client.matchConfirmationStatusHistory.create({
+    data: {
+      matchConfirmationId: matchConfirmationId,
+      status: "denied",
+      createdAt: new Date().toISOString(),
+    },
+  });
+}
+
+export async function updateTicketWithDenial(
+  zendeskTicketId: bigint,
+  volunteer: Pick<Volunteers, "firstName" | "zendeskUserId">
+) {
+  const ticket = {
+    id: zendeskTicketId,
+    custom_fields: [
+      {
+        id: ZENDESK_CUSTOM_FIELDS_DICIO["status_acolhimento"],
+        value: ZENDESK_TICKET_WAITING_FOR_MATCH_STATUS,
+      },
+    ],
+    comment: {
+      body: `A [Voluntária ${volunteer.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteer.zendeskUserId}) negou o match.
+            
+            O pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
+      public: false,
+    },
+  };
+
+  const zendeskTicket = await updateTicket(ticket);
+
+  if (!zendeskTicket)
+    throw new Error(
+      `Couldn't update msr Zendesk ticket for zendesk_ticket_id: ${zendeskTicketId}`
+    );
+}
+
+export async function addSupportRequestToQueue(supportRequestId: number) {
+  await client.supportRequests.update({
+    where: {
+      supportRequestId: supportRequestId,
+    },
+    data: {
+      status: "waiting_for_match",
+      updatedAt: new Date().toISOString(),
+      SupportRequestStatusHistory: {
+        create: {
+          status: "waiting_for_match",
+        },
+      },
+    },
+  });
+}
+
+export async function makeVolunteerAvailable(
+  volunteer: Pick<Volunteers, "id" | "zendeskUserId">
+) {
+  const volunteerZendeskUser: Pick<ZendeskUser, "id" | "user_fields"> = {
+    id: volunteer.zendeskUserId as bigint,
+    user_fields: { condition: ZENDESK_USER_AVAILABLE_STATUS },
+  };
+  const updatedZendeskUser = await updateUser(volunteerZendeskUser);
+
+  if (!updatedZendeskUser)
+    throw new Error(
+      `Couldn't update volunteer Zendesk status for zendesk_user_id: ${volunteer.zendeskUserId} `
+    );
+
+  await client.volunteers.update({
+    where: {
+      id: volunteer.id,
+    },
+    data: {
+      condition: ZENDESK_USER_AVAILABLE_STATUS,
+      updated_at: new Date().toISOString(),
+    },
+  });
+
+  await client.volunteerStatusHistory.create({
+    data: {
+      volunteer_id: volunteer.id,
+      status: ZENDESK_USER_AVAILABLE_STATUS,
+      created_at: new Date().toISOString(),
+    },
+  });
+
+  await client.volunteerAvailability.update({
+    where: {
+      volunteer_id: volunteer.id,
+    },
+    data: {
+      is_available: true,
+      updated_at: new Date().toISOString(),
+    },
+  });
+}
+
+export async function checkPreviousMatchConfirmations(
+  supportRequestId: number
+) {
+  const previousMatchConfirmations =
+    (await client.matchConfirmations.findMany({
+      where: {
+        supportRequestId: supportRequestId,
+        status: {
+          in: ["denied", "expired"],
+        },
+      },
+    })) || [];
+
+  if (previousMatchConfirmations.length === 0) return false;
+
+  return true;
+}
+
+export async function fetchMsrPii(msrId: bigint) {
+  const msrPii = client.mSRPiiSec.findUniqueOrThrow({
+    where: {
+      msrId: msrId,
+    },
+  });
+
+  return msrPii;
+}

--- a/src/matchDenied/matchDeniedLogic.ts
+++ b/src/matchDenied/matchDeniedLogic.ts
@@ -1,4 +1,4 @@
-import type { Volunteers } from "@prisma/client";
+import type { MatchConfirmations, Volunteers } from "@prisma/client";
 import type { ZendeskUser } from "../types";
 import updateTicket from "../zendeskClient/updateTicket";
 import client from "../prismaClient";
@@ -118,14 +118,20 @@ export async function makeVolunteerAvailable(
 }
 
 export async function checkPreviousMatchConfirmations(
-  supportRequestId: number
+  matchConfirmation: Pick<
+    MatchConfirmations,
+    "matchConfirmationId" | "supportRequestId"
+  >
 ) {
   const previousMatchConfirmations =
     (await client.matchConfirmations.findMany({
       where: {
-        supportRequestId: supportRequestId,
+        supportRequestId: matchConfirmation.supportRequestId,
         status: {
           in: ["denied", "expired"],
+        },
+        matchConfirmationId: {
+          not: matchConfirmation.matchConfirmationId,
         },
       },
     })) || [];

--- a/src/reply/__tests__/replyLogic.spec.ts
+++ b/src/reply/__tests__/replyLogic.spec.ts
@@ -1,5 +1,6 @@
 import {
   WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_ERROR_REPLY,
   WHATSAPP_GENERIC_REPLY,
   WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
   WHATSAPP_POSITIVE_REPLY,
@@ -13,6 +14,7 @@ import {
 } from "../__mocks__/utils";
 import {
   sendContinueAvailableReply,
+  sendErrorReply,
   sendGenericReply,
   sendNegativeReply,
   sendPositiveReply,
@@ -154,6 +156,32 @@ describe("replyLogic", () => {
 
     it("should return the reply that was sent", async () => {
       const res = await sendUnregistrationReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendErrorReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendErrorReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_ERROR_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should throw an error if message wasn't sent", async () => {
+      sendOpenReplyMock.mockResolvedValueOnce(null);
+
+      await expect(sendErrorReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendErrorReply(volunteerPhoneMock);
 
       expect(res).toStrictEqual(replyMock);
     });

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -26,6 +26,8 @@ const sendUnregistrationReplyMock = jest.spyOn(
 
 const sendGenericReplyMock = jest.spyOn(replyLogic, "sendGenericReply");
 
+const sendErrorReplyMock = jest.spyOn(replyLogic, "sendErrorReply");
+
 describe("sendReply", () => {
   beforeEach(() => {
     sendOpenReplyMock.mockResolvedValue(replyMock);
@@ -72,6 +74,12 @@ describe("sendReply", () => {
     await sendReply(phone, undefined);
 
     expect(sendGenericReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
+  });
+
+  it("should call sendErrorReply with correct params", async () => {
+    await sendReply(phone, ReplyType.error);
+
+    expect(sendErrorReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
   });
 
   it("should return the reply that was sent", async () => {

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -1,4 +1,3 @@
-import * as cleanPhone from "../../utils/cleanPhone";
 import sendReply from "../sendReply";
 import {
   replyMock,
@@ -7,11 +6,9 @@ import {
   volunteerPhoneMock,
 } from "../__mocks__";
 import * as replyLogic from "../replyLogic";
-import { ButtonText } from "../../types";
+import { ReplyType } from "../../types";
 
-const volunteerFrom = "whatsapp%3A%2B5511123456789";
-
-const cleanPhoneMock = jest.spyOn(cleanPhone, "default");
+const phone = "5511123456789";
 
 const sendPositiveReplyMock = jest.spyOn(replyLogic, "sendPositiveReply");
 
@@ -35,14 +32,8 @@ describe("sendReply", () => {
     sendTemplateMessageMock.mockResolvedValue(replyMock);
   });
 
-  it("should call cleanPhone with correct params", async () => {
-    await sendReply(volunteerFrom, ButtonText.positive);
-
-    expect(cleanPhoneMock).toHaveBeenNthCalledWith(1, volunteerFrom);
-  });
-
   it("should call sendPositiveReply with correct params", async () => {
-    await sendReply(volunteerFrom, ButtonText.positive);
+    await sendReply(phone, ReplyType.positive);
 
     expect(sendPositiveReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -51,7 +42,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendNegativeReply with correct params", async () => {
-    await sendReply(volunteerFrom, ButtonText.negative);
+    await sendReply(phone, ReplyType.negative);
 
     expect(sendNegativeReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -60,7 +51,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendContinueAvailableReply with correct params", async () => {
-    await sendReply(volunteerFrom, ButtonText.continue);
+    await sendReply(phone, ReplyType.continue);
 
     expect(sendContinueAvailableReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -69,7 +60,7 @@ describe("sendReply", () => {
   });
 
   it("should call sendUnregistrationReply with correct params", async () => {
-    await sendReply(volunteerFrom, ButtonText.unregistration);
+    await sendReply(phone, ReplyType.unregistration);
 
     expect(sendUnregistrationReplyMock).toHaveBeenNthCalledWith(
       1,
@@ -78,13 +69,13 @@ describe("sendReply", () => {
   });
 
   it("should call sendGenericReply with correct params", async () => {
-    await sendReply(volunteerFrom, undefined);
+    await sendReply(phone, undefined);
 
     expect(sendGenericReplyMock).toHaveBeenNthCalledWith(1, volunteerPhoneMock);
   });
 
   it("should return the reply that was sent", async () => {
-    const res = await sendReply(volunteerFrom, undefined);
+    const res = await sendReply(phone, undefined);
 
     expect(res).toStrictEqual(replyMock);
   });

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -1,5 +1,6 @@
 import {
   WHATSAPP_CONTINUE_AVAILABLE_REPLY,
+  WHATSAPP_ERROR_REPLY,
   WHATSAPP_GENERIC_REPLY,
   WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
   WHATSAPP_POSITIVE_REPLY,
@@ -48,6 +49,13 @@ export async function sendUnregistrationReply(phone: string) {
     phone,
     contentVariables
   );
+  if (!message || message.status !== "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
+  return message;
+}
+
+export async function sendErrorReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_ERROR_REPLY, phone);
   if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;

--- a/src/reply/sendReply.ts
+++ b/src/reply/sendReply.ts
@@ -1,7 +1,7 @@
-import { ButtonText, type TwilioMessage } from "../types";
-import { cleanPhone } from "../utils";
+import { ReplyType, type TwilioMessage } from "../types";
 import {
   sendContinueAvailableReply,
+  sendErrorReply,
   sendGenericReply,
   sendNegativeReply,
   sendPositiveReply,
@@ -10,25 +10,20 @@ import {
 
 export default async function sendReply(
   phone: string,
-  buttonText?: ButtonText
+  buttonText: ReplyType = ReplyType.generic
 ): Promise<TwilioMessage> {
-  const cleanedPhone = cleanPhone(phone);
-
-  if (!buttonText) {
-    const reply = await sendGenericReply(cleanedPhone);
-    return reply;
-  }
-
-  const ANSWER_TYPES = {
-    [ButtonText.positive]: sendPositiveReply,
-    [ButtonText.negative]: sendNegativeReply,
-    [ButtonText.continue]: sendContinueAvailableReply,
-    [ButtonText.unregistration]: sendUnregistrationReply,
+  const REPLY_FUNCTIONS = {
+    [ReplyType.positive]: sendPositiveReply,
+    [ReplyType.negative]: sendNegativeReply,
+    [ReplyType.continue]: sendContinueAvailableReply,
+    [ReplyType.unregistration]: sendUnregistrationReply,
+    [ReplyType.generic]: sendGenericReply,
+    [ReplyType.error]: sendErrorReply,
   };
 
-  const sendReply = ANSWER_TYPES[buttonText] || sendGenericReply;
+  const replyFunction = REPLY_FUNCTIONS[buttonText];
 
-  const reply = await sendReply(cleanedPhone);
+  const reply = await replyFunction(phone);
 
   return reply;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,9 +8,11 @@ import {
 export * from "./Zendesk";
 export * from "./Twilio";
 
-export enum ButtonText {
+export enum ReplyType {
   positive = POSITIVE_ANSWER,
   negative = NEGATIVE_ANSWER,
   unregistration = UNREGISTRATION_ANSWER,
   continue = CONTINUE_AVAILABLE_ANSWER,
+  generic = "NO BUTTON TEXT",
+  error = "ERROR",
 }


### PR DESCRIPTION
Esse PR adiciona a lógica para o caso da Voluntária negar o match.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/58769124-ba3e-45a4-bd80-9f2d9b771d81">

Para isso, foi feito um refactor no endpoint `/handle-answer`. Antes, esse endpoint chamava duas funções separadas `processMatchConfirmation` e `sendReply`. Agora, esse endpoint passa a chamar a função `handleVolunteerAnswer` que, por sua vez, irá chamar as outras duas funções a depender do caso.

