### PR TITLE
[MAPA-513] feat: expire match_confirmation

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -3,3 +3,4 @@ export { default as auth } from "./src/auth";
 export { default as featureFlag } from "./src/featureFlag";
 export { default as createConfirmation } from "./src/createConfirmation";
 export { default as handleAnswer } from "./src/handleAnswer";
+export { default as expire } from "./src/expire";

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -89,6 +89,14 @@ functions:
       - httpApi:
           path: /handle-answer
           method: POST
+  
+  expire:
+    handler: handler.expire
+    timeout: 30
+    events:
+      - httpApi:
+          path: /expire
+          method: POST
 
 plugins:
   - serverless-webpack

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -97,6 +97,9 @@ functions:
       - httpApi:
           path: /expire
           method: POST
+          authorizer:
+            name: auth
+            type: request
 
 plugins:
   - serverless-webpack

--- a/src/__tests__/expire.spec.ts
+++ b/src/__tests__/expire.spec.ts
@@ -12,6 +12,7 @@ import {
   volunteerMock,
 } from "../matchConfirmation/__mocks__";
 import type { MSRPiiSec } from "@prisma/client";
+import { replyMock, sendOpenReplyMock } from "../reply/__mocks__";
 
 const callback = jest.fn();
 
@@ -106,6 +107,7 @@ describe("/expire endpoint", () => {
     prismaMock.volunteers.findUniqueOrThrow.mockResolvedValueOnce(
       volunteerMock
     );
+    sendOpenReplyMock.mockResolvedValue(replyMock);
 
     await expire(
       {

--- a/src/__tests__/expire.spec.ts
+++ b/src/__tests__/expire.spec.ts
@@ -1,0 +1,128 @@
+import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import { expire } from "../../handler";
+import { prismaMock } from "../setupTests";
+import * as expireMatch from "../matchExpired/expireMatch";
+import {
+  matchConfirmationMock,
+  msrZendeskTicketMock,
+  supportRequestMock,
+  updatedUserMock,
+  updateTicketMock,
+  updateUserMock,
+  volunteerMock,
+} from "../matchConfirmation/__mocks__";
+import type { MSRPiiSec } from "@prisma/client";
+
+const callback = jest.fn();
+
+const defaultBody = {
+  matchConfirmationId: 1,
+};
+
+const expireMatchMock = jest.spyOn(expireMatch, "default");
+
+const msrPIIMock = {
+  email: "msr@gmail.com",
+  firstName: "MSR",
+} as MSRPiiSec;
+
+describe("/expire endpoint", () => {
+  it("should return an error res when no body is provided to the req", async () => {
+    await expire(
+      {
+        body: null,
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        error: "Validation error: matchConfirmationId is a required field",
+      }),
+    });
+  });
+
+  it("should return an error res when req body is invalid", async () => {
+    await expire(
+      {
+        body: JSON.stringify({
+          supportRequestId: 1,
+        }),
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        error: `Validation error: matchConfirmationId is a required field`,
+      }),
+    });
+  });
+
+  it("should call expireMatch with correct params", async () => {
+    await expire(
+      {
+        body: JSON.stringify(defaultBody),
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+
+    expect(expireMatchMock).toHaveBeenNthCalledWith(
+      1,
+      defaultBody.matchConfirmationId
+    );
+  });
+
+  it("should return an error if match_confirmation wasn't found", async () => {
+    prismaMock.matchConfirmations.findUnique.mockResolvedValueOnce(null);
+    await expire(
+      {
+        body: JSON.stringify(defaultBody),
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: `Couldn't expire match confirmation for match_confirmation_id: ${defaultBody.matchConfirmationId}`,
+      }),
+    });
+  });
+
+  it("should return the match_confirmation", async () => {
+    updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
+    updateUserMock.mockResolvedValueOnce(updatedUserMock);
+    prismaMock.mSRPiiSec.findUniqueOrThrow.mockResolvedValueOnce(msrPIIMock);
+    prismaMock.matchConfirmations.findUnique.mockResolvedValueOnce(
+      matchConfirmationMock
+    );
+    prismaMock.supportRequests.findUniqueOrThrow.mockResolvedValueOnce(
+      supportRequestMock
+    );
+    prismaMock.volunteers.findUniqueOrThrow.mockResolvedValueOnce(
+      volunteerMock
+    );
+
+    await expire(
+      {
+        body: JSON.stringify(defaultBody),
+      } as APIGatewayProxyEvent,
+      {} as Context,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: {
+          matchConfirmationId: matchConfirmationMock.matchConfirmationId,
+          status: "expired",
+        },
+      }),
+    });
+  });
+});

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -44,6 +44,7 @@ export const WHATSAPP_CONTINUE_AVAILABLE_REPLY = `Obrigada pelo seu retorno! Em 
 export const WHATSAPP_ERROR_REPLY = `Ops, parece que essa solicitação já foi processada. Se estiver enfrentando alguma dificuldade, por favor, entre em contato pelo e-mail: voluntaria@mapadoacolhimento.org`;
 export const WHATSAPP_UNREGISTRATION_REPLY_TEMPLATE_ID =
   "HX3ccc5212f22ecc0dbb2d27096374fb2c";
+export const WHATSAPP_EXPIRATION_REPLY = `Como não recebemos o seu retorno a tempo, encaminhamos o pedido de ajuda para outra voluntária. De toda forma, obrigada pela sua dedicação a essa rede potente de acolhimento e solidariedade. Em breve você terá outras oportunidades de atendimento. 💜`;
 
 // VOLUNTEER ANSWERS
 export const POSITIVE_ANSWER = "Sim";

--- a/src/expire.ts
+++ b/src/expire.ts
@@ -52,7 +52,7 @@ export default async function handler(
     if (error["name"] === "ValidationError") {
       const errorMsg = `Validation error: ${getErrorMessage(error)}`;
 
-      console.error(`[create-match-confirmation] - [400]: ${errorMsg}`);
+      console.error(`[expire] - [400]: ${errorMsg}`);
 
       return callback(null, {
         statusCode: 400,
@@ -63,7 +63,7 @@ export default async function handler(
     }
 
     const errorMsg = getErrorMessage(error);
-    console.error(`[create-match-confirmation] - [500]: ${errorMsg}`);
+    console.error(`[expire] - [500]: ${errorMsg}`);
 
     return callback(null, {
       statusCode: 500,

--- a/src/expire.ts
+++ b/src/expire.ts
@@ -1,0 +1,73 @@
+import type {
+  APIGatewayEvent,
+  Context,
+  APIGatewayProxyCallback,
+} from "aws-lambda";
+import { object, number } from "yup";
+import { getErrorMessage, isJsonString, stringfyBigInt } from "./utils";
+import expireMatch from "./matchExpired/expireMatch";
+
+const bodySchema = object({
+  matchConfirmationId: number().required(),
+})
+  .required()
+  .strict();
+
+export default async function handler(
+  event: APIGatewayEvent,
+  _context: Context,
+  callback: APIGatewayProxyCallback
+) {
+  try {
+    const body = event.body;
+
+    const parsedBody = isJsonString(body)
+      ? (JSON.parse(body as string) as unknown)
+      : (Object.create(null) as Record<string, unknown>);
+
+    const validatedBody = await bodySchema.validate(parsedBody);
+
+    const { matchConfirmationId } = validatedBody;
+
+    const matchConfirmation = await expireMatch(matchConfirmationId);
+
+    if (!matchConfirmation)
+      throw new Error(
+        `Couldn't expire match confirmation for match_confirmation_id: ${matchConfirmationId}`
+      );
+
+    const bodyRes = JSON.stringify({
+      message: stringfyBigInt({
+        matchConfirmationId: matchConfirmation.matchConfirmationId,
+        status: "expired",
+      }),
+    });
+
+    return callback(null, {
+      statusCode: 200,
+      body: bodyRes,
+    });
+  } catch (e) {
+    const error = e as Record<string, unknown>;
+    if (error["name"] === "ValidationError") {
+      const errorMsg = `Validation error: ${getErrorMessage(error)}`;
+
+      console.error(`[create-match-confirmation] - [400]: ${errorMsg}`);
+
+      return callback(null, {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: errorMsg,
+        }),
+      });
+    }
+
+    const errorMsg = getErrorMessage(error);
+    console.error(`[create-match-confirmation] - [500]: ${errorMsg}`);
+
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({ error: errorMsg }),
+    });
+  }
+}

--- a/src/handleVolunteerAnswer/__tests__/handleVolunteerAnswer.spec.ts
+++ b/src/handleVolunteerAnswer/__tests__/handleVolunteerAnswer.spec.ts
@@ -63,7 +63,7 @@ describe("handleVolunteerAnswer", () => {
 
       expect(sendReplyMock).toHaveBeenNthCalledWith(
         1,
-        "5511123456789",
+        "11123456789",
         ReplyType.unregistration
       );
     });
@@ -103,7 +103,7 @@ describe("handleVolunteerAnswer", () => {
 
       expect(sendReplyMock).toHaveBeenNthCalledWith(
         1,
-        "5511123456789",
+        "11123456789",
         ReplyType.error
       );
     });
@@ -117,7 +117,7 @@ describe("handleVolunteerAnswer", () => {
 
       expect(sendReplyMock).toHaveBeenNthCalledWith(
         1,
-        "5511123456789",
+        "11123456789",
         ReplyType.positive
       );
     });

--- a/src/matchExpired/__tests__/expireMatch.spec.ts
+++ b/src/matchExpired/__tests__/expireMatch.spec.ts
@@ -11,9 +11,11 @@ import {
 import * as matchConfirmationLogic from "../../matchConfirmation/matchConfirmationLogic";
 import * as matchExpiredLogic from "../matchExpiredLogic";
 import * as matchDeniedLogic from "../../matchDenied/matchDeniedLogic";
+import * as replyLogic from "../../reply/replyLogic";
 import * as emailClient from "../../emailClient/index";
 import { prismaMock } from "../../setupTests";
 import type { MSRPiiSec } from "@prisma/client";
+import { replyMock, sendOpenReplyMock } from "../../reply/__mocks__";
 
 const fetchMatchConfirmationMock = jest.spyOn(
   matchConfirmationLogic,
@@ -45,6 +47,8 @@ const makeVolunteerAvailableMock = jest.spyOn(
   "makeVolunteerAvailable"
 );
 
+const sendExpirationReplyMock = jest.spyOn(replyLogic, "sendExpirationReply");
+
 const checkPreviousMatchConfirmationsMock = jest.spyOn(
   matchDeniedLogic,
   "checkPreviousMatchConfirmations"
@@ -75,6 +79,7 @@ describe("expireMatch", () => {
     prismaMock.volunteers.findUniqueOrThrow.mockResolvedValueOnce(
       volunteerMock
     );
+    sendOpenReplyMock.mockResolvedValue(replyMock);
   });
 
   it("should call fetchMatchConfirmation with correct params", async () => {
@@ -137,6 +142,15 @@ describe("expireMatch", () => {
     expect(makeVolunteerAvailableMock).toHaveBeenNthCalledWith(
       1,
       volunteerMock
+    );
+  });
+
+  it("should call sendExpirationReplyMock with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(sendExpirationReplyMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerMock.phone
     );
   });
 

--- a/src/matchExpired/__tests__/expireMatch.spec.ts
+++ b/src/matchExpired/__tests__/expireMatch.spec.ts
@@ -1,0 +1,196 @@
+import expireMatch from "../expireMatch";
+import {
+  matchConfirmationMock,
+  msrZendeskTicketMock,
+  supportRequestMock,
+  updatedUserMock,
+  updateTicketMock,
+  updateUserMock,
+  volunteerMock,
+} from "../../matchConfirmation/__mocks__";
+import * as matchConfirmationLogic from "../../matchConfirmation/matchConfirmationLogic";
+import * as matchExpiredLogic from "../matchExpiredLogic";
+import * as matchDeniedLogic from "../../matchDenied/matchDeniedLogic";
+import * as emailClient from "../../emailClient/index";
+import { prismaMock } from "../../setupTests";
+import type { MSRPiiSec } from "@prisma/client";
+
+const fetchMatchConfirmationMock = jest.spyOn(
+  matchConfirmationLogic,
+  "fetchMatchConfirmation"
+);
+
+const fetchSupportRequestAndVolunteerMock = jest.spyOn(
+  matchConfirmationLogic,
+  "fetchSupportRequestAndVolunteer"
+);
+
+const updateTicketWithExpirationMock = jest.spyOn(
+  matchExpiredLogic,
+  "updateTicketWithExpiration"
+);
+
+const expireMatchConfirmationMock = jest.spyOn(
+  matchExpiredLogic,
+  "expireMatchConfirmation"
+);
+
+const addSupportRequestToQueueMock = jest.spyOn(
+  matchDeniedLogic,
+  "addSupportRequestToQueue"
+);
+
+const makeVolunteerAvailableMock = jest.spyOn(
+  matchDeniedLogic,
+  "makeVolunteerAvailable"
+);
+
+const checkPreviousMatchConfirmationsMock = jest.spyOn(
+  matchDeniedLogic,
+  "checkPreviousMatchConfirmations"
+);
+
+const fetchMsrPiiMock = jest.spyOn(matchDeniedLogic, "fetchMsrPii");
+
+const sendEmailToMsrMock = jest
+  .spyOn(emailClient, "sendEmailToMsr")
+  .mockImplementation(() => Promise.resolve(true));
+
+const msrPIIMock = {
+  email: "msr@gmail.com",
+  firstName: "MSR",
+} as MSRPiiSec;
+
+describe("expireMatch", () => {
+  beforeEach(() => {
+    updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
+    updateUserMock.mockResolvedValueOnce(updatedUserMock);
+    prismaMock.mSRPiiSec.findUniqueOrThrow.mockResolvedValueOnce(msrPIIMock);
+    prismaMock.matchConfirmations.findUnique.mockResolvedValueOnce(
+      matchConfirmationMock
+    );
+    prismaMock.supportRequests.findUniqueOrThrow.mockResolvedValueOnce(
+      supportRequestMock
+    );
+    prismaMock.volunteers.findUniqueOrThrow.mockResolvedValueOnce(
+      volunteerMock
+    );
+  });
+
+  it("should call fetchMatchConfirmation with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(fetchMatchConfirmationMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.matchConfirmationId
+    );
+  });
+
+  it("should return null if no match_confirmation was found", async () => {
+    fetchMatchConfirmationMock.mockResolvedValueOnce(null);
+    const res = await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(res).toStrictEqual(null);
+  });
+
+  it("should call fetchSupportRequestAndVolunteer with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(fetchSupportRequestAndVolunteerMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.supportRequestId,
+      matchConfirmationMock.volunteerId
+    );
+  });
+
+  it("should call updateTicketWithExpiration with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(updateTicketWithExpirationMock).toHaveBeenNthCalledWith(
+      1,
+      supportRequestMock.zendeskTicketId,
+      volunteerMock
+    );
+  });
+
+  it("should call expireMatchConfirmation with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(expireMatchConfirmationMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.matchConfirmationId
+    );
+  });
+
+  it("should call addSupportRequestToQueue with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(addSupportRequestToQueueMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock.supportRequestId
+    );
+  });
+
+  it("should call makeVolunteerAvailable with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(makeVolunteerAvailableMock).toHaveBeenNthCalledWith(
+      1,
+      volunteerMock
+    );
+  });
+
+  it("should call checkPreviousMatchConfirmations with correct params", async () => {
+    await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(checkPreviousMatchConfirmationsMock).toHaveBeenNthCalledWith(
+      1,
+      matchConfirmationMock
+    );
+  });
+
+  it("should return the matchConfirmation", async () => {
+    const res = await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+    expect(res).toStrictEqual(matchConfirmationMock);
+  });
+
+  describe("should send email to MSR if she doesn't have previous match confirmations", () => {
+    it("should call fetchMsrPii with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(false);
+      await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+      expect(fetchMsrPiiMock).toHaveBeenNthCalledWith(
+        1,
+        matchConfirmationMock.msrId
+      );
+    });
+
+    it("should call sendEmailToMsr with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(false);
+      await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+      expect(sendEmailToMsrMock).toHaveBeenNthCalledWith(
+        1,
+        msrPIIMock,
+        supportRequestMock
+      );
+    });
+  });
+
+  describe("should not send email to MSR if she has previous match confirmations", () => {
+    it("should not call fetchMsrPii", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(true);
+      await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+      expect(fetchMsrPiiMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("should not call sendEmailToMsr with correct params", async () => {
+      checkPreviousMatchConfirmationsMock.mockResolvedValueOnce(true);
+      await expireMatch(matchConfirmationMock.matchConfirmationId);
+
+      expect(sendEmailToMsrMock).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/matchExpired/__tests__/matchExpiredLogic.spec.ts
+++ b/src/matchExpired/__tests__/matchExpiredLogic.spec.ts
@@ -1,0 +1,43 @@
+import {
+  msrZendeskTicketMock,
+  supportRequestMock,
+  updateTicketMock,
+  volunteerMock,
+} from "../../matchConfirmation/__mocks__";
+import { updateTicketWithExpiration } from "../matchExpiredLogic";
+
+describe("updateTicketWithExpiration", () => {
+  it("should call updateTicket with correct params", async () => {
+    updateTicketMock.mockResolvedValueOnce(msrZendeskTicketMock);
+
+    await updateTicketWithExpiration(
+      supportRequestMock.zendeskTicketId,
+      volunteerMock
+    );
+
+    expect(updateTicketMock).toHaveBeenNthCalledWith(1, {
+      id: supportRequestMock.zendeskTicketId,
+      custom_fields: [
+        {
+          id: 360014379412,
+          value: "aguardando_match__sem_prioridade",
+        },
+      ],
+      comment: {
+        body: `A [Voluntária ${volunteerMock.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteerMock.zendeskUserId}) não respondeu após 24h.\n\nO pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
+        public: false,
+      },
+    });
+  });
+
+  it("should throw an error if no ticket was updated on Zendesk", async () => {
+    updateTicketMock.mockResolvedValueOnce(null);
+
+    await expect(
+      updateTicketWithExpiration(
+        supportRequestMock.zendeskTicketId,
+        volunteerMock
+      )
+    ).rejects.toThrow("Couldn't update msr Zendesk ticket");
+  });
+});

--- a/src/matchExpired/expireMatch.ts
+++ b/src/matchExpired/expireMatch.ts
@@ -1,0 +1,47 @@
+import { sendEmailToMsr } from "../emailClient";
+import {
+  fetchMatchConfirmation,
+  fetchSupportRequestAndVolunteer,
+} from "../matchConfirmation/matchConfirmationLogic";
+import {
+  addSupportRequestToQueue,
+  checkPreviousMatchConfirmations,
+  fetchMsrPii,
+  makeVolunteerAvailable,
+} from "../matchDenied/matchDeniedLogic";
+import {
+  expireMatchConfirmation,
+  updateTicketWithExpiration,
+} from "./matchExpiredLogic";
+
+export default async function expireMatch(matchConfirmationId: number) {
+  const matchConfirmation = await fetchMatchConfirmation(matchConfirmationId);
+
+  console.log({ matchConfirmation });
+
+  if (!matchConfirmation) return null;
+
+  const { supportRequest, volunteer } = await fetchSupportRequestAndVolunteer(
+    matchConfirmation.supportRequestId,
+    matchConfirmation.volunteerId
+  );
+
+  await updateTicketWithExpiration(supportRequest.zendeskTicketId, volunteer);
+
+  await expireMatchConfirmation(matchConfirmation.matchConfirmationId);
+
+  await addSupportRequestToQueue(matchConfirmation.supportRequestId);
+
+  await makeVolunteerAvailable(volunteer);
+
+  const hasPreviousMatchConfirmations =
+    await checkPreviousMatchConfirmations(matchConfirmation);
+
+  if (!hasPreviousMatchConfirmations) {
+    const msrPii = await fetchMsrPii(matchConfirmation.msrId);
+
+    await sendEmailToMsr(msrPii, supportRequest);
+  }
+
+  return matchConfirmation;
+}

--- a/src/matchExpired/expireMatch.ts
+++ b/src/matchExpired/expireMatch.ts
@@ -9,6 +9,7 @@ import {
   fetchMsrPii,
   makeVolunteerAvailable,
 } from "../matchDenied/matchDeniedLogic";
+import { sendExpirationReply } from "../reply/replyLogic";
 import {
   expireMatchConfirmation,
   updateTicketWithExpiration,
@@ -31,6 +32,8 @@ export default async function expireMatch(matchConfirmationId: number) {
   await addSupportRequestToQueue(matchConfirmation.supportRequestId);
 
   await makeVolunteerAvailable(volunteer);
+
+  await sendExpirationReply(volunteer.phone);
 
   const hasPreviousMatchConfirmations =
     await checkPreviousMatchConfirmations(matchConfirmation);

--- a/src/matchExpired/expireMatch.ts
+++ b/src/matchExpired/expireMatch.ts
@@ -17,8 +17,6 @@ import {
 export default async function expireMatch(matchConfirmationId: number) {
   const matchConfirmation = await fetchMatchConfirmation(matchConfirmationId);
 
-  console.log({ matchConfirmation });
-
   if (!matchConfirmation) return null;
 
   const { supportRequest, volunteer } = await fetchSupportRequestAndVolunteer(

--- a/src/matchExpired/matchExpiredLogic.ts
+++ b/src/matchExpired/matchExpiredLogic.ts
@@ -1,0 +1,53 @@
+import type { Volunteers } from "@prisma/client";
+import {
+  ZENDESK_CUSTOM_FIELDS_DICIO,
+  ZENDESK_TICKET_WAITING_FOR_MATCH_STATUS,
+} from "../constants";
+import updateTicket from "../zendeskClient/updateTicket";
+import client from "../prismaClient";
+
+export async function updateTicketWithExpiration(
+  zendeskTicketId: bigint,
+  volunteer: Pick<Volunteers, "firstName" | "zendeskUserId">
+) {
+  const ticket = {
+    id: zendeskTicketId,
+    custom_fields: [
+      {
+        id: ZENDESK_CUSTOM_FIELDS_DICIO["status_acolhimento"],
+        value: ZENDESK_TICKET_WAITING_FOR_MATCH_STATUS,
+      },
+    ],
+    comment: {
+      body: `A [Voluntária ${volunteer.firstName}](https://mapadoacolhimento.zendesk.com/agent/users/${volunteer.zendeskUserId}) não respondeu após 24h.\n\nO pedido de acolhimento foi encaminhado para a fila do Match Diário.`,
+      public: false,
+    },
+  };
+
+  const zendeskTicket = await updateTicket(ticket);
+
+  if (!zendeskTicket)
+    throw new Error(
+      `Couldn't update msr Zendesk ticket for zendesk_ticket_id: ${zendeskTicketId}`
+    );
+}
+
+export async function expireMatchConfirmation(matchConfirmationId: number) {
+  await client.matchConfirmations.update({
+    where: {
+      matchConfirmationId: matchConfirmationId,
+    },
+    data: {
+      status: "expired",
+      updatedAt: new Date().toISOString(),
+    },
+  });
+
+  await client.matchConfirmationStatusHistory.create({
+    data: {
+      matchConfirmationId: matchConfirmationId,
+      status: "expired",
+      createdAt: new Date().toISOString(),
+    },
+  });
+}

--- a/src/reply/__mocks__/utils.ts
+++ b/src/reply/__mocks__/utils.ts
@@ -14,4 +14,4 @@ export const replyMock = {
   status: "accepted",
 } as TwilioMessage;
 
-export const volunteerPhoneMock = "5511123456789";
+export const volunteerPhoneMock = "11123456789";

--- a/src/reply/__tests__/replyLogic.spec.ts
+++ b/src/reply/__tests__/replyLogic.spec.ts
@@ -1,6 +1,7 @@
 import {
   WHATSAPP_CONTINUE_AVAILABLE_REPLY,
   WHATSAPP_ERROR_REPLY,
+  WHATSAPP_EXPIRATION_REPLY,
   WHATSAPP_GENERIC_REPLY,
   WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
   WHATSAPP_POSITIVE_REPLY,
@@ -15,6 +16,7 @@ import {
 import {
   sendContinueAvailableReply,
   sendErrorReply,
+  sendExpirationReply,
   sendGenericReply,
   sendNegativeReply,
   sendPositiveReply,
@@ -182,6 +184,32 @@ describe("replyLogic", () => {
 
     it("should return the reply that was sent", async () => {
       const res = await sendErrorReply(volunteerPhoneMock);
+
+      expect(res).toStrictEqual(replyMock);
+    });
+  });
+
+  describe("sendExpirationReply", () => {
+    it("should call sendOpenReply with correct params", async () => {
+      await sendExpirationReply(volunteerPhoneMock);
+
+      expect(sendOpenReplyMock).toHaveBeenNthCalledWith(
+        1,
+        WHATSAPP_EXPIRATION_REPLY,
+        volunteerPhoneMock
+      );
+    });
+
+    it("should throw an error if message wasn't sent", async () => {
+      sendOpenReplyMock.mockResolvedValueOnce(null);
+
+      await expect(sendExpirationReply(volunteerPhoneMock)).rejects.toThrow(
+        `Couldn't send whatsapp message to phone: ${volunteerPhoneMock}`
+      );
+    });
+
+    it("should return the reply that was sent", async () => {
+      const res = await sendExpirationReply(volunteerPhoneMock);
 
       expect(res).toStrictEqual(replyMock);
     });

--- a/src/reply/__tests__/sendReply.spec.ts
+++ b/src/reply/__tests__/sendReply.spec.ts
@@ -8,7 +8,7 @@ import {
 import * as replyLogic from "../replyLogic";
 import { ReplyType } from "../../types";
 
-const phone = "5511123456789";
+const phone = "11123456789";
 
 const sendPositiveReplyMock = jest.spyOn(replyLogic, "sendPositiveReply");
 

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -1,6 +1,7 @@
 import {
   WHATSAPP_CONTINUE_AVAILABLE_REPLY,
   WHATSAPP_ERROR_REPLY,
+  WHATSAPP_EXPIRATION_REPLY,
   WHATSAPP_GENERIC_REPLY,
   WHATSAPP_NEGATIVE_REPLY_TEMPLATE_ID,
   WHATSAPP_POSITIVE_REPLY,
@@ -56,6 +57,13 @@ export async function sendUnregistrationReply(phone: string) {
 
 export async function sendErrorReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_ERROR_REPLY, phone);
+  if (!message || message.status !== "accepted")
+    throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
+  return message;
+}
+
+export async function sendExpirationReply(phone: string) {
+  const message = await sendOpenReply(WHATSAPP_EXPIRATION_REPLY, phone);
   if (!message || message.status !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;

--- a/src/twilioClient/sendOpenReply.ts
+++ b/src/twilioClient/sendOpenReply.ts
@@ -8,7 +8,7 @@ export default async function sendOpenReply(
 ): Promise<TwilioMessage | null> {
   const message = await twilioClient.messages.create({
     from: WHATSAPP_SENDER_ID!,
-    to: "whatsapp:+" + phone,
+    to: "whatsapp:+55" + phone,
     body: body,
   });
 

--- a/src/twilioClient/sendTemplateMessage.ts
+++ b/src/twilioClient/sendTemplateMessage.ts
@@ -11,7 +11,7 @@ export default async function sendTemplateMessage(
     contentSid: templateId,
     contentVariables: JSON.stringify(contentVariables),
     from: WHATSAPP_SENDER_ID!,
-    to: "whatsapp:+" + phone,
+    to: "whatsapp:+55" + phone,
   });
 
   return message;

--- a/src/types/Zendesk.ts
+++ b/src/types/Zendesk.ts
@@ -7,10 +7,6 @@ export type ZendeskUser = {
   };
 };
 
-export type ZendeskUserRes = {
-  user: ZendeskUser;
-};
-
 export type UpdateZendeskUser = Partial<Omit<ZendeskUser, "id">> & {
   id: bigint;
 };
@@ -25,7 +21,3 @@ export type UpdateZendeskTicket = Partial<Omit<ZendeskTicket, "id">> & {
 };
 
 export type CreateZendeskTicket = Omit<ZendeskTicket, "id">;
-
-export type ZendeskTicketRes = {
-  ticket: ZendeskTicket;
-};

--- a/src/utils/__tests__/cleanPhone.spec.ts
+++ b/src/utils/__tests__/cleanPhone.spec.ts
@@ -1,0 +1,9 @@
+import cleanPhone from "../cleanPhone";
+
+describe("cleanPhone", () => {
+  it("should clean the phone number, returning the last 11 digits", () => {
+    const res = cleanPhone("whatsapp:+5511123456789");
+
+    expect(res).toStrictEqual("11123456789");
+  });
+});

--- a/src/utils/cleanPhone.ts
+++ b/src/utils/cleanPhone.ts
@@ -1,3 +1,3 @@
 export default function cleanPhone(phone: string) {
-  return phone.slice(-13);
+  return phone.slice(-11);
 }

--- a/src/zendeskClient/updateTicket.ts
+++ b/src/zendeskClient/updateTicket.ts
@@ -6,11 +6,7 @@ import {
   ZENDESK_API_URL,
   ZENDESK_API_USER,
 } from "../constants";
-import type {
-  UpdateZendeskTicket,
-  ZendeskTicket,
-  ZendeskTicketRes,
-} from "../types";
+import type { UpdateZendeskTicket, ZendeskTicket } from "../types";
 
 export default async function updateTicket(
   ticket: UpdateZendeskTicket
@@ -34,13 +30,13 @@ export default async function updateTicket(
       },
     });
 
-    if (!response.ok) {
-      throw new Error(response.statusText);
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (data["error"] && response.status !== 200) {
+      throw new Error(getErrorMessage(data));
     }
 
-    const data = (await response.json()) as ZendeskTicketRes;
-
-    return data.ticket;
+    return data["ticket"] as ZendeskTicket;
   } catch (e) {
     console.error(
       `[updateTicket] - Something went wrong when updating this ticket '${

--- a/src/zendeskClient/updateUser.ts
+++ b/src/zendeskClient/updateUser.ts
@@ -6,7 +6,7 @@ import {
   ZENDESK_API_URL,
   ZENDESK_API_USER,
 } from "../constants";
-import type { UpdateZendeskUser, ZendeskUser, ZendeskUserRes } from "../types";
+import type { UpdateZendeskUser, ZendeskUser } from "../types";
 
 export default async function updateUser(
   user: UpdateZendeskUser
@@ -29,13 +29,13 @@ export default async function updateUser(
       },
     });
 
-    if (!response.ok) {
-      throw new Error(response.statusText);
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (data["error"] && response.status !== 200) {
+      throw new Error(getErrorMessage(data));
     }
 
-    const data = (await response.json()) as ZendeskUserRes;
-
-    return data.user;
+    return data["user"] as ZendeskUser;
   } catch (e) {
     console.error(
       `[updateUser] - Something went wrong when updating this user on Zendesk '${


### PR DESCRIPTION
Esse PR adiciona o endpoint `/expire` que irá expirar as match_confirmations, conforme a imagem a seguir:
<img width="502" alt="image" src="https://github.com/user-attachments/assets/50068392-0de4-4c6e-a99f-52827e8ba131">

Esse endpoint será chamado por um workflow no n8n que rodará a cada 1h.
