### PR TITLE
[MAPA-515] fix: return twilio message status to prevent errors

### DIFF
--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -6,12 +6,8 @@ import { replyMock } from "../reply/__mocks__";
 
 const callback = jest.fn();
 
-const defaultBody = {
-  MessageType: "text",
-  Body: "Oi",
-  MessageSid: "SM802c0d39a503aae472cee7379abff9f6",
-  From: "whatsapp%3A%2B5511123456789",
-};
+const defaultBody =
+  "MessageType=text&Body=Oi&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5511123456789";
 
 const sendReplyMock = jest.spyOn(sendReply, "default");
 const handleVolunteerAnswerMock = jest.spyOn(handleVolunteerAnswer, "default");
@@ -28,7 +24,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 400,
       body: JSON.stringify({
-        error: "Empty request body",
+        error: "Validation error: From is a required field",
       }),
     });
   });
@@ -54,7 +50,7 @@ describe("/handle-answer endpoint", () => {
   it("should call handleVolunteerAnswer with correct params", async () => {
     await handleAnswer(
       {
-        body: JSON.stringify(defaultBody),
+        body: defaultBody,
       } as APIGatewayProxyEvent,
       {} as Context,
       callback
@@ -75,7 +71,7 @@ describe("/handle-answer endpoint", () => {
 
     await handleAnswer(
       {
-        body: JSON.stringify(defaultBody),
+        body: defaultBody,
       } as APIGatewayProxyEvent,
       {} as Context,
       callback
@@ -94,7 +90,7 @@ describe("/handle-answer endpoint", () => {
 
     await handleAnswer(
       {
-        body: JSON.stringify(defaultBody),
+        body: defaultBody,
       } as APIGatewayProxyEvent,
       {} as Context,
       callback

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -24,7 +24,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 400,
       body: JSON.stringify({
-        error: "Validation error: From is a required field",
+        error: "Empty request body",
       }),
     });
   });

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -98,7 +98,7 @@ describe("/handle-answer endpoint", () => {
 
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 200,
-      body: replyMock,
+      body: "",
     });
   });
 });

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -98,7 +98,7 @@ describe("/handle-answer endpoint", () => {
 
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 200,
-      body: JSON.stringify({ message: replyMock }),
+      body: replyMock,
     });
   });
 });

--- a/src/__tests__/handleAnswer.spec.ts
+++ b/src/__tests__/handleAnswer.spec.ts
@@ -6,8 +6,12 @@ import { replyMock } from "../reply/__mocks__";
 
 const callback = jest.fn();
 
-const defaultBody =
-  "MessageType=text&Body=Oi&MessageSid=SM802c0d39a503aae472cee7379abff9f6&From=whatsapp%3A%2B5511123456789";
+const defaultBody = {
+  MessageType: "text",
+  Body: "Oi",
+  MessageSid: "SM802c0d39a503aae472cee7379abff9f6",
+  From: "whatsapp%3A%2B5511123456789",
+};
 
 const sendReplyMock = jest.spyOn(sendReply, "default");
 const handleVolunteerAnswerMock = jest.spyOn(handleVolunteerAnswer, "default");
@@ -24,7 +28,7 @@ describe("/handle-answer endpoint", () => {
     expect(callback).toHaveBeenCalledWith(null, {
       statusCode: 400,
       body: JSON.stringify({
-        error: "Validation error: From is a required field",
+        error: "Empty request body",
       }),
     });
   });
@@ -50,7 +54,7 @@ describe("/handle-answer endpoint", () => {
   it("should call handleVolunteerAnswer with correct params", async () => {
     await handleAnswer(
       {
-        body: defaultBody,
+        body: JSON.stringify(defaultBody),
       } as APIGatewayProxyEvent,
       {} as Context,
       callback
@@ -71,7 +75,7 @@ describe("/handle-answer endpoint", () => {
 
     await handleAnswer(
       {
-        body: defaultBody,
+        body: JSON.stringify(defaultBody),
       } as APIGatewayProxyEvent,
       {} as Context,
       callback
@@ -90,7 +94,7 @@ describe("/handle-answer endpoint", () => {
 
     await handleAnswer(
       {
-        body: defaultBody,
+        body: JSON.stringify(defaultBody),
       } as APIGatewayProxyEvent,
       {} as Context,
       callback

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -4,7 +4,7 @@ import type {
   APIGatewayProxyCallback,
 } from "aws-lambda";
 import { object, string } from "yup";
-import { getErrorMessage, isJsonString } from "./utils";
+import { getErrorMessage, parseParamsToJson } from "./utils";
 import handleVolunteerAnswer from "./handleVolunteerAnswer/handleVolunteerAnswer";
 import { ReplyType } from "./types";
 
@@ -23,21 +23,9 @@ export default async function handler(
   try {
     const body = event.body;
 
-    if (!body) {
-      const errorMessage = "Empty request body";
-      console.error(`[handle-answer] - [400]: ${errorMessage}`);
-
-      return callback(null, {
-        statusCode: 400,
-        body: JSON.stringify({
-          error: errorMessage,
-        }),
-      });
-    }
-
-    const parsedBody = isJsonString(body)
-      ? (JSON.parse(body) as unknown)
-      : (Object.create(null) as Record<string, unknown>);
+    const parsedBody =
+      (parseParamsToJson(body) as unknown) ||
+      (Object.create(null) as Record<string, unknown>);
 
     const validatedBody = await bodySchema.validate(parsedBody);
 

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -21,11 +21,17 @@ export default async function handler(
   callback: APIGatewayProxyCallback
 ) {
   try {
+    console.log("Received event", JSON.stringify(event, null, 2));
+
     const body = event.body;
+
+    console.log({ body });
 
     const parsedBody =
       (parseParamsToJson(body) as unknown) ||
       (Object.create(null) as Record<string, unknown>);
+
+    console.log({ parsedBody });
 
     const validatedBody = await bodySchema.validate(parsedBody);
 

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -21,17 +21,29 @@ export default async function handler(
   callback: APIGatewayProxyCallback
 ) {
   try {
-    console.log("Received event", JSON.stringify(event, null, 2));
+    let body = event.body;
+    const isBase64Encoded = event.isBase64Encoded;
 
-    const body = event.body;
+    if (!body) {
+      const errorMessage = "Empty request body";
+      console.error(`[create-match] - [400]: ${errorMessage}`);
 
-    console.log({ body });
+      return callback(null, {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: errorMessage,
+        }),
+      });
+    }
+
+    if (isBase64Encoded) {
+      const buff = Buffer.from(body, "base64");
+      body = buff.toString("utf8");
+    }
 
     const parsedBody =
       (parseParamsToJson(body) as unknown) ||
       (Object.create(null) as Record<string, unknown>);
-
-    console.log({ parsedBody });
 
     const validatedBody = await bodySchema.validate(parsedBody);
 

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -4,7 +4,7 @@ import type {
   APIGatewayProxyCallback,
 } from "aws-lambda";
 import { object, string } from "yup";
-import { getErrorMessage, stringfyBigInt, parseParamsToJson } from "./utils";
+import { getErrorMessage, parseParamsToJson } from "./utils";
 import handleVolunteerAnswer from "./handleVolunteerAnswer/handleVolunteerAnswer";
 import { ReplyType } from "./types";
 
@@ -37,13 +37,9 @@ export default async function handler(
 
     const reply = await handleVolunteerAnswer(from, buttonText, buttonPayload);
 
-    const bodyRes = JSON.stringify({
-      message: stringfyBigInt(reply),
-    });
-
     return callback(null, {
       statusCode: 200,
-      body: bodyRes,
+      body: reply,
     });
   } catch (e) {
     const error = e as Record<string, unknown>;

--- a/src/handleAnswer.ts
+++ b/src/handleAnswer.ts
@@ -53,11 +53,11 @@ export default async function handler(
       ButtonPayload: buttonPayload,
     } = validatedBody;
 
-    const reply = await handleVolunteerAnswer(from, buttonText, buttonPayload);
+    await handleVolunteerAnswer(from, buttonText, buttonPayload);
 
     return callback(null, {
       statusCode: 200,
-      body: reply,
+      body: "",
     });
   } catch (e) {
     const error = e as Record<string, unknown>;

--- a/src/matchConfirmation/__mocks__/utils.ts
+++ b/src/matchConfirmation/__mocks__/utils.ts
@@ -10,7 +10,6 @@ import type {
   Volunteers,
 } from "@prisma/client";
 import type { ZendeskTicket, ZendeskUser } from "../../types";
-import type { TwilioMessage } from "../../types/Twilio";
 import * as updateTicket from "../../zendeskClient/updateTicket";
 import * as updateUser from "../../zendeskClient/updateUser";
 import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
@@ -82,6 +81,4 @@ export const sendTemplateMessageMock = jest
   .spyOn(sendTemplateMessage, "default")
   .mockImplementation(() => Promise.resolve(null));
 
-export const sentMessageMock = {
-  status: "accepted",
-} as TwilioMessage;
+export const sentMessageMock = "accepted";

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -187,7 +187,7 @@ export async function sendWhatsAppMessage(
       contentVariables
     );
 
-    if (!message || message.status != "accepted")
+    if (message != "accepted")
       throw new Error(
         `Couldn't send whatsapp message to volunteer for volunteer_id: ${volunteer.id}`
       );
@@ -220,7 +220,7 @@ export async function sendWhatsAppMessage(
     }
   );
 
-  if (!message || message.status != "accepted")
+  if (message != "accepted")
     throw new Error(
       `Couldn't send whatsapp message to volunteer for volunteer_id: ${volunteer.id}`
     );

--- a/src/matchConfirmation/matchConfirmationLogic.ts
+++ b/src/matchConfirmation/matchConfirmationLogic.ts
@@ -187,7 +187,7 @@ export async function sendWhatsAppMessage(
       contentVariables
     );
 
-    if (message != "accepted")
+    if (message !== "accepted")
       throw new Error(
         `Couldn't send whatsapp message to volunteer for volunteer_id: ${volunteer.id}`
       );
@@ -220,7 +220,7 @@ export async function sendWhatsAppMessage(
     }
   );
 
-  if (message != "accepted")
+  if (message !== "accepted")
     throw new Error(
       `Couldn't send whatsapp message to volunteer for volunteer_id: ${volunteer.id}`
     );

--- a/src/reply/__mocks__/utils.ts
+++ b/src/reply/__mocks__/utils.ts
@@ -1,6 +1,5 @@
 import * as sendOpenReply from "../../twilioClient/sendOpenReply";
 import * as sendTemplateMessage from "../../twilioClient/sendTemplateMessage";
-import type { TwilioMessage } from "../../types";
 
 export const sendOpenReplyMock = jest
   .spyOn(sendOpenReply, "default")
@@ -10,8 +9,6 @@ export const sendTemplateMessageMock = jest
   .spyOn(sendTemplateMessage, "default")
   .mockImplementation(() => Promise.resolve(null));
 
-export const replyMock = {
-  status: "accepted",
-} as TwilioMessage;
+export const replyMock = "accepted";
 
 export const volunteerPhoneMock = "11123456789";

--- a/src/reply/replyLogic.ts
+++ b/src/reply/replyLogic.ts
@@ -12,14 +12,14 @@ import sendTemplateMessage from "../twilioClient/sendTemplateMessage";
 
 export async function sendGenericReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_GENERIC_REPLY, phone);
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendPositiveReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_POSITIVE_REPLY, phone);
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
@@ -31,14 +31,14 @@ export async function sendNegativeReply(phone: string) {
     phone,
     contentVariables
   );
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendContinueAvailableReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_CONTINUE_AVAILABLE_REPLY, phone);
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
@@ -50,21 +50,21 @@ export async function sendUnregistrationReply(phone: string) {
     phone,
     contentVariables
   );
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendErrorReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_ERROR_REPLY, phone);
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }
 
 export async function sendExpirationReply(phone: string) {
   const message = await sendOpenReply(WHATSAPP_EXPIRATION_REPLY, phone);
-  if (!message || message.status !== "accepted")
+  if (message !== "accepted")
     throw new Error(`Couldn't send whatsapp message to phone: ${phone}`);
   return message;
 }

--- a/src/reply/sendReply.ts
+++ b/src/reply/sendReply.ts
@@ -1,4 +1,4 @@
-import { ReplyType, type TwilioMessage } from "../types";
+import { ReplyType } from "../types";
 import {
   sendContinueAvailableReply,
   sendErrorReply,
@@ -11,7 +11,7 @@ import {
 export default async function sendReply(
   phone: string,
   buttonText: ReplyType = ReplyType.generic
-): Promise<TwilioMessage> {
+) {
   const REPLY_FUNCTIONS = {
     [ReplyType.positive]: sendPositiveReply,
     [ReplyType.negative]: sendNegativeReply,

--- a/src/twilioClient/sendOpenReply.ts
+++ b/src/twilioClient/sendOpenReply.ts
@@ -1,16 +1,15 @@
 import twilioClient from ".";
 import { WHATSAPP_SENDER_ID } from "../constants";
-import type { TwilioMessage } from "../types/Twilio";
 
 export default async function sendOpenReply(
   body: string,
   phone: string
-): Promise<TwilioMessage | null> {
+): Promise<string | null> {
   const message = await twilioClient.messages.create({
     from: WHATSAPP_SENDER_ID!,
     to: "whatsapp:+55" + phone,
     body: body,
   });
 
-  return message;
+  return message.status;
 }

--- a/src/twilioClient/sendOpenReply.ts
+++ b/src/twilioClient/sendOpenReply.ts
@@ -11,5 +11,5 @@ export default async function sendOpenReply(
     body: body,
   });
 
-  return message.status;
+  return message?.status || null;
 }

--- a/src/twilioClient/sendTemplateMessage.ts
+++ b/src/twilioClient/sendTemplateMessage.ts
@@ -13,5 +13,5 @@ export default async function sendTemplateMessage(
     to: "whatsapp:+55" + phone,
   });
 
-  return message.status;
+  return message?.status || null;
 }

--- a/src/twilioClient/sendTemplateMessage.ts
+++ b/src/twilioClient/sendTemplateMessage.ts
@@ -1,12 +1,11 @@
 import twilioClient from ".";
 import { WHATSAPP_SENDER_ID } from "../constants";
-import type { TwilioMessage } from "../types/Twilio";
 
 export default async function sendTemplateMessage(
   templateId: string,
   phone: string,
   contentVariables: Record<string, string> | null
-): Promise<TwilioMessage | null> {
+): Promise<string | null> {
   const message = await twilioClient.messages.create({
     contentSid: templateId,
     contentVariables: JSON.stringify(contentVariables),
@@ -14,5 +13,5 @@ export default async function sendTemplateMessage(
     to: "whatsapp:+55" + phone,
   });
 
-  return message;
+  return message.status;
 }


### PR DESCRIPTION
Esse PR faz dois fixes necessários:
- Adiciona uma lógica para decodificar o body da requisição quando necessário;
- Retorna apenas o status da mensagem enviada em vez da mensagem inteira (isso estava gerando um erro);