### PR TITLE
fix: fixes cleanPhone to consider numbers with less than 11 characters

### DIFF
--- a/src/utils/cleanPhone.ts
+++ b/src/utils/cleanPhone.ts
@@ -1,3 +1,3 @@
 export default function cleanPhone(phone: string) {
-  return phone.slice(-11);
+  return phone.replace("whatsapp:+55", "").replace("whatsapp%3A%2B55", "");
 }


### PR DESCRIPTION
Esse PR faz um fix na função `cleanPhone` porque alguns números de telefone não têm 11 dígitos.